### PR TITLE
Ci/release

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,8 +1,6 @@
 {
     "extends": "./.c8rc.base.json",
-    "include": [
-        "packages/**/src/**"
-    ],
+    "include": ["packages/**/src/**"],
     "exclude": [
         "packages/vinyl-build-utils/**",
         "packages/vinyl-jasmine-wrapper/**",

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,20 +1,20 @@
 name: PR
 
 on:
-  pull_request:
-    branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .tool-versions
-          cache: npm
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .tool-versions
+                  cache: npm
 
-      - run: npm ci
+            - run: npm ci
 
-      - run: npm run release
+            - run: npm run release

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,51 +1,55 @@
 name: Release Publish
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
+    pull_request:
+        types: [closed]
+        branches: [main]
 
 concurrency:
-  group: release-publish
-  cancel-in-progress: false
+    group: release-publish
+    cancel-in-progress: false
 
 jobs:
-  publish:
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: main
-          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
+    publish:
+        if:
+            github.event.pull_request.merged == true &&
+            startsWith(github.event.pull_request.head.ref, 'release/v')
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  ref: main
+                  token: ${{ secrets.RELEASE_PUSH_TOKEN }}
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .tool-versions
-          cache: npm
-          registry-url: https://registry.npmjs.org
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .tool-versions
+                  cache: npm
+                  registry-url: https://registry.npmjs.org
 
-      - run: npm ci
+            - run: npm ci
 
-      - run: npm run release
+            - run: npm run release
 
-      - name: Tag
-        run: |
-          VERSION=$(node -p "require('./lerna.json').version")
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${VERSION}" -m "v${VERSION}"
-          git push origin "v${VERSION}"
+            - name: Tag
+              run: |
+                  VERSION=$(node -p "require('./lerna.json').version")
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git tag -a "v${VERSION}" -m "v${VERSION}"
+                  git push origin "v${VERSION}"
 
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "v$(node -p "require('./lerna.json').version")" --generate-notes
+            - name: Create GitHub release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run:
+                  gh release create "v$(node -p
+                  "require('./lerna.json').version")" --generate-notes
 
-      - name: Publish to npm
-        run: npx lerna publish from-package --yes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+            - name: Publish to npm
+              run: npx lerna publish from-package --yes
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,51 @@
+name: Release Publish
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      - run: npm run release
+
+      - name: Tag
+        run: |
+          VERSION=$(node -p "require('./lerna.json').version")
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "v${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "v$(node -p "require('./lerna.json').version")" --generate-notes
+
+      - name: Publish to npm
+        run: npx lerna publish from-package --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,54 @@
+name: Version
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: version
+  cancel-in-progress: false
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
+          cache: npm
+
+      - run: npm ci
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate version and changelogs
+        run: npx lerna version --conventional-commits --yes --no-git-tag-version --no-push
+
+      - name: Format
+        run: npx prettier . --write
+
+      - name: Commit and open PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./lerna.json').version")
+          BRANCH="release/v${VERSION}"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore(release): ${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(release): ${VERSION}" \
+            --body "Automated release PR. Merging will tag v${VERSION} and publish to npm."

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,54 +1,56 @@
 name: Version
 
 on:
-  workflow_dispatch:
+    workflow_dispatch:
 
 concurrency:
-  group: version
-  cancel-in-progress: false
+    group: version
+    cancel-in-progress: false
 
 jobs:
-  version:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
+    version:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.RELEASE_PUSH_TOKEN }}
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .tool-versions
-          cache: npm
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .tool-versions
+                  cache: npm
 
-      - run: npm ci
+            - run: npm ci
 
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            - name: Configure git identity
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Generate version and changelogs
-        run: npx lerna version --conventional-commits --yes --no-git-tag-version --no-push
+            - name: Generate version and changelogs
+              run:
+                  npx lerna version --conventional-commits --yes
+                  --no-git-tag-version --no-push
 
-      - name: Format
-        run: npx prettier . --write
+            - name: Format
+              run: npx prettier . --write
 
-      - name: Commit and open PR
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
-        run: |
-          VERSION=$(node -p "require('./lerna.json').version")
-          BRANCH="release/v${VERSION}"
-          git checkout -b "$BRANCH"
-          git add -A
-          git commit -m "chore(release): ${VERSION}"
-          git push origin "$BRANCH"
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore(release): ${VERSION}" \
-            --body "Automated release PR. Merging will tag v${VERSION} and publish to npm."
+            - name: Commit and open PR
+              env:
+                  GH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
+              run: |
+                  VERSION=$(node -p "require('./lerna.json').version")
+                  BRANCH="release/v${VERSION}"
+                  git checkout -b "$BRANCH"
+                  git add -A
+                  git commit -m "chore(release): ${VERSION}"
+                  git push origin "$BRANCH"
+                  gh pr create \
+                    --base main \
+                    --head "$BRANCH" \
+                    --title "chore(release): ${VERSION}" \
+                    --body "Automated release PR. Merging will tag v${VERSION} and publish to npm."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))
+- **streaming:** prevent duplicate playback on timeline misalignment
+  ([466d936](https://github.com/amazonmusic/vinyl/commits/466d93690c9845fe826b7a4c3103d54c8c27a967))

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,7 @@
 ## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+
+This project has adopted the
+[Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). For
+more information see the
+[Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,59 +1,78 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
-documentation, we greatly value feedback and contributions from our community.
+Thank you for your interest in contributing to our project. Whether it's a bug
+report, new feature, correction, or additional documentation, we greatly value
+feedback and contributions from our community.
 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
-information to effectively respond to your bug report or contribution.
-
+Please read through this document before submitting any issues or pull requests
+to ensure we have all the necessary information to effectively respond to your
+bug report or contribution.
 
 ## Reporting Bugs/Feature Requests
 
-We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+We welcome you to use the GitHub issue tracker to report bugs or suggest
+features.
 
-When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
-reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+When filing an issue, please check existing open, or recently closed, issues to
+make sure somebody else hasn't already reported the issue. Please try to include
+as much information as you can. Details like these are incredibly useful:
 
-* A reproducible test case or series of steps
-* The version of our code being used
-* Any modifications you've made relevant to the bug
-* Anything unusual about your environment or deployment
-
+- A reproducible test case or series of steps
+- The version of our code being used
+- Any modifications you've made relevant to the bug
+- Anything unusual about your environment or deployment
 
 ## Contributing via Pull Requests
-Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *main* branch.
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
-3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+Contributions via pull requests are much appreciated. Before sending us a pull
+request, please ensure that:
+
+1. You are working against the latest source on the _main_ branch.
+2. You check existing open, and recently merged, pull requests to make sure
+   someone else hasn't addressed the problem already.
+3. You open an issue to discuss any significant work - we would hate for your
+   time to be wasted.
 
 To send us a pull request, please:
 
 1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
+2. Modify the source; please focus on the specific change you are contributing.
+   If you also reformat all the code, it will be hard for us to focus on your
+   change.
 3. Ensure local tests pass.
 4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+5. Send us a pull request, answering any default questions in the pull request
+   interface.
+6. Pay attention to any automated CI failures reported in the pull request, and
+   stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+GitHub provides additional document on
+[forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
+Looking at the existing issues is a great way to find something to contribute
+on. As our projects, by default, use the default GitHub issue labels
+(enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any
+'help wanted' issues is a great place to start.
 
 ## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+
+This project has adopted the
+[Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). For
+more information see the
+[Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.
 
-
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
+If you discover a potential security issue in this project we ask that you
+notify AWS/Amazon Security via our
+[vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/).
+Please do **not** create a public github issue.
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to
+confirm the licensing of your contribution.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -97,7 +97,8 @@ should be prefixed with an underscore.
 Booleans should not be prefixed with `is`. Example: Prefer `active` over
 ~~`isActive`~~.
 
-Acronyms should use camel case. Example: Prefer `HlsParser` over ~~`HLSParser`~~.
+Acronyms should use camel case. Example: Prefer `HlsParser` over
+~~`HLSParser`~~.
 
 ### type or interface?
 
@@ -225,7 +226,10 @@ paths (`@/`):
 #### ✅ Correct
 
 ```typescript
-import { createResourceTypeFilter, type MediaQualityFilter } from '@amazon/vinyl'
+import {
+    createResourceTypeFilter,
+    type MediaQualityFilter,
+} from '@amazon/vinyl'
 ```
 
 #### ❌ Incorrect

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
     "packages": ["./", "packages/*"],
-    "version": "0.0.0",
+    "version": "1.0.0",
     "command": {
         "publish": {
             "forcePublish": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -16994,25 +16994,25 @@
         },
         "packages/vinyl": {
             "name": "@amazon/vinyl",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@amazon/vinyl-di": "^0.0.0",
-                "@amazon/vinyl-hls-parser": "^0.0.0",
-                "@amazon/vinyl-mpd-parser": "^0.0.0",
-                "@amazon/vinyl-observable": "^0.0.0",
-                "@amazon/vinyl-transmux": "^0.0.0",
-                "@amazon/vinyl-util": "^0.0.0",
-                "@amazon/vinyl-validation": "^0.0.0"
+                "@amazon/vinyl-di": "^1.0.0",
+                "@amazon/vinyl-hls-parser": "^1.0.0",
+                "@amazon/vinyl-mpd-parser": "^1.0.0",
+                "@amazon/vinyl-observable": "^1.0.0",
+                "@amazon/vinyl-transmux": "^1.0.0",
+                "@amazon/vinyl-util": "^1.0.0",
+                "@amazon/vinyl-validation": "^1.0.0"
             },
             "devDependencies": {
-                "@amazon/vinyl-build-utils": "^0.0.0",
+                "@amazon/vinyl-build-utils": "^1.0.0",
                 "commander": "^9.5.0"
             }
         },
         "packages/vinyl-build-utils": {
             "name": "@amazon/vinyl-build-utils",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
                 "express": "^5.1.0",
@@ -17289,133 +17289,133 @@
         },
         "packages/vinyl-cache-manager": {
             "name": "@amazon/vinyl-cache-manager",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@amazon/vinyl-util": "^0.0.0"
+                "@amazon/vinyl-util": "^1.0.0"
             },
             "devDependencies": {
-                "@amazon/vinyl-build-utils": "^0.0.0",
-                "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+                "@amazon/vinyl-build-utils": "^1.0.0",
+                "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
             }
         },
         "packages/vinyl-di": {
             "name": "@amazon/vinyl-di",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@amazon/vinyl-util": "^0.0.0"
+                "@amazon/vinyl-util": "^1.0.0"
             },
             "devDependencies": {
-                "@amazon/vinyl-build-utils": "^0.0.0",
-                "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+                "@amazon/vinyl-build-utils": "^1.0.0",
+                "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
             }
         },
         "packages/vinyl-hls-parser": {
             "name": "@amazon/vinyl-hls-parser",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@amazon/vinyl-util": "^0.0.0",
-                "@amazon/vinyl-validation": "^0.0.0"
+                "@amazon/vinyl-util": "^1.0.0",
+                "@amazon/vinyl-validation": "^1.0.0"
             },
             "devDependencies": {
-                "@amazon/vinyl-build-utils": "^0.0.0",
-                "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+                "@amazon/vinyl-build-utils": "^1.0.0",
+                "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
             }
         },
         "packages/vinyl-jasmine-wrapper": {
             "name": "@amazon/vinyl-jasmine-wrapper",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED"
         },
         "packages/vinyl-mock-generator": {
             "name": "@amazon/vinyl-mock-generator",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED"
         },
         "packages/vinyl-mpd-parser": {
             "name": "@amazon/vinyl-mpd-parser",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@amazon/vinyl-util": "^0.0.0",
-                "@amazon/vinyl-validation": "^0.0.0",
-                "@amazon/vinyl-xml": "^0.0.0"
+                "@amazon/vinyl-util": "^1.0.0",
+                "@amazon/vinyl-validation": "^1.0.0",
+                "@amazon/vinyl-xml": "^1.0.0"
             },
             "devDependencies": {
-                "@amazon/vinyl-build-utils": "^0.0.0",
-                "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+                "@amazon/vinyl-build-utils": "^1.0.0",
+                "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
             }
         },
         "packages/vinyl-observable": {
             "name": "@amazon/vinyl-observable",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@amazon/vinyl-util": "^0.0.0"
+                "@amazon/vinyl-util": "^1.0.0"
             },
             "devDependencies": {
-                "@amazon/vinyl-build-utils": "^0.0.0",
-                "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+                "@amazon/vinyl-build-utils": "^1.0.0",
+                "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
             }
         },
         "packages/vinyl-transmux": {
             "name": "@amazon/vinyl-transmux",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@amazon/vinyl-util": "^0.0.0"
+                "@amazon/vinyl-util": "^1.0.0"
             },
             "devDependencies": {
-                "@amazon/vinyl-build-utils": "^0.0.0",
-                "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+                "@amazon/vinyl-build-utils": "^1.0.0",
+                "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
             }
         },
         "packages/vinyl-tsx": {
             "name": "@amazon/vinyl-tsx",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@amazon/vinyl-observable": "^0.0.0",
-                "@amazon/vinyl-util": "^0.0.0"
+                "@amazon/vinyl-observable": "^1.0.0",
+                "@amazon/vinyl-util": "^1.0.0"
             },
             "devDependencies": {
-                "@amazon/vinyl-build-utils": "^0.0.0",
-                "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+                "@amazon/vinyl-build-utils": "^1.0.0",
+                "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
             }
         },
         "packages/vinyl-util": {
             "name": "@amazon/vinyl-util",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "devDependencies": {
-                "@amazon/vinyl-build-utils": "^0.0.0",
-                "@amazon/vinyl-jasmine-wrapper": "^0.0.0",
-                "@amazon/vinyl-mock-generator": "^0.0.0"
+                "@amazon/vinyl-build-utils": "^1.0.0",
+                "@amazon/vinyl-jasmine-wrapper": "^1.0.0",
+                "@amazon/vinyl-mock-generator": "^1.0.0"
             }
         },
         "packages/vinyl-validation": {
             "name": "@amazon/vinyl-validation",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@amazon/vinyl-util": "^0.0.0"
+                "@amazon/vinyl-util": "^1.0.0"
             },
             "devDependencies": {
-                "@amazon/vinyl-build-utils": "^0.0.0",
-                "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+                "@amazon/vinyl-build-utils": "^1.0.0",
+                "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
             }
         },
         "packages/vinyl-website": {
             "name": "@amazon/vinyl-website",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@amazon/vinyl": "^0.0.0",
-                "@amazon/vinyl-observable": "^0.0.0",
-                "@amazon/vinyl-tsx": "^0.0.0",
-                "@amazon/vinyl-util": "^0.0.0"
+                "@amazon/vinyl": "^1.0.0",
+                "@amazon/vinyl-observable": "^1.0.0",
+                "@amazon/vinyl-tsx": "^1.0.0",
+                "@amazon/vinyl-util": "^1.0.0"
             },
             "devDependencies": {
                 "glob": "^13.0.0",
@@ -17520,15 +17520,15 @@
         },
         "packages/vinyl-xml": {
             "name": "@amazon/vinyl-xml",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@amazon/vinyl-util": "^0.0.0",
-                "@amazon/vinyl-validation": "^0.0.0"
+                "@amazon/vinyl-util": "^1.0.0",
+                "@amazon/vinyl-validation": "^1.0.0"
             },
             "devDependencies": {
-                "@amazon/vinyl-build-utils": "^0.0.0",
-                "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+                "@amazon/vinyl-build-utils": "^1.0.0",
+                "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://code.amazon.com/packages/Vinyl"
+        "url": "https://github.com/amazonmusic/vinyl"
     },
     "scripts": {
         "analyzeExports": "lerna run build:release && lerna run analyzeExports --stream",

--- a/packages/vinyl-build-utils/CHANGELOG.md
+++ b/packages/vinyl-build-utils/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-build-utils/package.json
+++ b/packages/vinyl-build-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-build-utils",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "Build utilities and configuration for TypeScript libraries.",
     "repository": {
         "type": "git",

--- a/packages/vinyl-build-utils/package.json
+++ b/packages/vinyl-build-utils/package.json
@@ -4,7 +4,7 @@
     "description": "Build utilities and configuration for TypeScript libraries.",
     "repository": {
         "type": "git",
-        "url": "https://code.amazon.com/packages/Vinyl"
+        "url": "https://github.com/amazonmusic/vinyl"
     },
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/vinyl-cache-manager/CHANGELOG.md
+++ b/packages/vinyl-cache-manager/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-cache-manager/package.json
+++ b/packages/vinyl-cache-manager/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-cache-manager",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "A mediator for the Cache API",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -66,11 +66,11 @@
         "watch:release": "tsx buildSrc/build.ts --watch --release"
     },
     "devDependencies": {
-        "@amazon/vinyl-build-utils": "^0.0.0",
-        "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+        "@amazon/vinyl-build-utils": "^1.0.0",
+        "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
     },
     "dependencies": {
-        "@amazon/vinyl-util": "^0.0.0"
+        "@amazon/vinyl-util": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"

--- a/packages/vinyl-cache-manager/package.json
+++ b/packages/vinyl-cache-manager/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-cache-manager",
     "version": "0.0.0",
     "description": "A mediator for the Cache API",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "main": "./dist/index.cjs",

--- a/packages/vinyl-di/CHANGELOG.md
+++ b/packages/vinyl-di/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-di/package.json
+++ b/packages/vinyl-di/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-di",
     "version": "0.0.0",
     "description": "Simple dependency injection",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "main": "./dist/index.cjs",

--- a/packages/vinyl-di/package.json
+++ b/packages/vinyl-di/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-di",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "Simple dependency injection",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -66,11 +66,11 @@
         "watch:release": "tsx buildSrc/build.ts --watch --release"
     },
     "devDependencies": {
-        "@amazon/vinyl-build-utils": "^0.0.0",
-        "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+        "@amazon/vinyl-build-utils": "^1.0.0",
+        "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
     },
     "dependencies": {
-        "@amazon/vinyl-util": "^0.0.0"
+        "@amazon/vinyl-util": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"

--- a/packages/vinyl-hls-parser/CHANGELOG.md
+++ b/packages/vinyl-hls-parser/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-hls-parser/package.json
+++ b/packages/vinyl-hls-parser/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-hls-parser",
     "version": "0.0.0",
     "description": "A fast HLS manifest parser for browser and Node.",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "main": "./dist/index.cjs",

--- a/packages/vinyl-hls-parser/package.json
+++ b/packages/vinyl-hls-parser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-hls-parser",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "A fast HLS manifest parser for browser and Node.",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -72,12 +72,12 @@
         "watch:release": "tsx buildSrc/build.ts --watch --release"
     },
     "devDependencies": {
-        "@amazon/vinyl-build-utils": "^0.0.0",
-        "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+        "@amazon/vinyl-build-utils": "^1.0.0",
+        "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
     },
     "dependencies": {
-        "@amazon/vinyl-util": "^0.0.0",
-        "@amazon/vinyl-validation": "^0.0.0"
+        "@amazon/vinyl-util": "^1.0.0",
+        "@amazon/vinyl-validation": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"

--- a/packages/vinyl-jasmine-wrapper/CHANGELOG.md
+++ b/packages/vinyl-jasmine-wrapper/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-jasmine-wrapper/package.json
+++ b/packages/vinyl-jasmine-wrapper/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-jasmine-wrapper",
     "version": "0.0.0",
     "description": "A wrapper for jasmine core to allow an html runner to boot on legacy browsers",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/vinyl-jasmine-wrapper/package.json
+++ b/packages/vinyl-jasmine-wrapper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-jasmine-wrapper",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "A wrapper for jasmine core to allow an html runner to boot on legacy browsers",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",

--- a/packages/vinyl-mock-generator/CHANGELOG.md
+++ b/packages/vinyl-mock-generator/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-mock-generator/package.json
+++ b/packages/vinyl-mock-generator/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-mock-generator",
     "version": "0.0.0",
     "description": "Generates mock classes from interfaces",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "main": "./dist/index.cjs",
     "types": "dist/index.d.ts",

--- a/packages/vinyl-mock-generator/package.json
+++ b/packages/vinyl-mock-generator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-mock-generator",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "Generates mock classes from interfaces",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",

--- a/packages/vinyl-mpd-parser/CHANGELOG.md
+++ b/packages/vinyl-mpd-parser/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-mpd-parser/package.json
+++ b/packages/vinyl-mpd-parser/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-mpd-parser",
     "version": "0.0.0",
     "description": "A fast dash manifest parser for browser and Node.",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "main": "./dist/index.cjs",

--- a/packages/vinyl-mpd-parser/package.json
+++ b/packages/vinyl-mpd-parser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-mpd-parser",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "A fast dash manifest parser for browser and Node.",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -84,13 +84,13 @@
         "watch:release": "tsx buildSrc/build.ts --watch --release"
     },
     "devDependencies": {
-        "@amazon/vinyl-build-utils": "^0.0.0",
-        "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+        "@amazon/vinyl-build-utils": "^1.0.0",
+        "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
     },
     "dependencies": {
-        "@amazon/vinyl-util": "^0.0.0",
-        "@amazon/vinyl-validation": "^0.0.0",
-        "@amazon/vinyl-xml": "^0.0.0"
+        "@amazon/vinyl-util": "^1.0.0",
+        "@amazon/vinyl-validation": "^1.0.0",
+        "@amazon/vinyl-xml": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"

--- a/packages/vinyl-observable/CHANGELOG.md
+++ b/packages/vinyl-observable/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-observable/package.json
+++ b/packages/vinyl-observable/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-observable",
     "version": "0.0.0",
     "description": "A simple active model",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "main": "./dist/index.cjs",

--- a/packages/vinyl-observable/package.json
+++ b/packages/vinyl-observable/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-observable",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "A simple active model",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -66,11 +66,11 @@
         "watch:release": "tsx buildSrc/build.ts --watch --release"
     },
     "devDependencies": {
-        "@amazon/vinyl-build-utils": "^0.0.0",
-        "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+        "@amazon/vinyl-build-utils": "^1.0.0",
+        "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
     },
     "dependencies": {
-        "@amazon/vinyl-util": "^0.0.0"
+        "@amazon/vinyl-util": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"

--- a/packages/vinyl-transmux/CHANGELOG.md
+++ b/packages/vinyl-transmux/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-transmux/package.json
+++ b/packages/vinyl-transmux/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-transmux",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "MPEG-TS to fMP4 transmuxer for browser and Node.",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -67,11 +67,11 @@
         "watch:release": "tsx buildSrc/build.ts --watch --release"
     },
     "devDependencies": {
-        "@amazon/vinyl-build-utils": "^0.0.0",
-        "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+        "@amazon/vinyl-build-utils": "^1.0.0",
+        "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
     },
     "dependencies": {
-        "@amazon/vinyl-util": "^0.0.0"
+        "@amazon/vinyl-util": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"

--- a/packages/vinyl-transmux/package.json
+++ b/packages/vinyl-transmux/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-transmux",
     "version": "0.0.0",
     "description": "MPEG-TS to fMP4 transmuxer for browser and Node.",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "main": "./dist/index.cjs",

--- a/packages/vinyl-tsx/CHANGELOG.md
+++ b/packages/vinyl-tsx/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-tsx/package.json
+++ b/packages/vinyl-tsx/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-tsx",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "TSX declarative markup for creating UI",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -66,12 +66,12 @@
         "watch:release": "tsx buildSrc/build.ts --watch --release"
     },
     "devDependencies": {
-        "@amazon/vinyl-build-utils": "^0.0.0",
-        "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+        "@amazon/vinyl-build-utils": "^1.0.0",
+        "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
     },
     "dependencies": {
-        "@amazon/vinyl-util": "^0.0.0",
-        "@amazon/vinyl-observable": "^0.0.0"
+        "@amazon/vinyl-observable": "^1.0.0",
+        "@amazon/vinyl-util": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"

--- a/packages/vinyl-tsx/package.json
+++ b/packages/vinyl-tsx/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-tsx",
     "version": "0.0.0",
     "description": "TSX declarative markup for creating UI",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "main": "./dist/index.cjs",

--- a/packages/vinyl-util/CHANGELOG.md
+++ b/packages/vinyl-util/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-util/package.json
+++ b/packages/vinyl-util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-util",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "Standard utilities for browser and node.",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -105,9 +105,9 @@
         "watch:release": "tsx buildSrc/build.ts --watch --release"
     },
     "devDependencies": {
-        "@amazon/vinyl-build-utils": "^0.0.0",
-        "@amazon/vinyl-mock-generator": "^0.0.0",
-        "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+        "@amazon/vinyl-build-utils": "^1.0.0",
+        "@amazon/vinyl-jasmine-wrapper": "^1.0.0",
+        "@amazon/vinyl-mock-generator": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"

--- a/packages/vinyl-util/package.json
+++ b/packages/vinyl-util/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-util",
     "version": "0.0.0",
     "description": "Standard utilities for browser and node.",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "main": "./dist/index.cjs",

--- a/packages/vinyl-validation/CHANGELOG.md
+++ b/packages/vinyl-validation/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-validation/package.json
+++ b/packages/vinyl-validation/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-validation",
     "version": "0.0.0",
     "description": "Basic input shape validation",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "main": "./dist/index.cjs",

--- a/packages/vinyl-validation/package.json
+++ b/packages/vinyl-validation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-validation",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "Basic input shape validation",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -67,11 +67,11 @@
         "watch:release": "tsx buildSrc/build.ts --watch --release"
     },
     "devDependencies": {
-        "@amazon/vinyl-build-utils": "^0.0.0",
-        "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+        "@amazon/vinyl-build-utils": "^1.0.0",
+        "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
     },
     "dependencies": {
-        "@amazon/vinyl-util": "^0.0.0"
+        "@amazon/vinyl-util": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"

--- a/packages/vinyl-website/CHANGELOG.md
+++ b/packages/vinyl-website/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))
+- **streaming:** prevent duplicate playback on timeline misalignment
+  ([466d936](https://github.com/amazonmusic/vinyl/commits/466d93690c9845fe826b7a4c3103d54c8c27a967))

--- a/packages/vinyl-website/package.json
+++ b/packages/vinyl-website/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-website",
     "version": "0.0.0",
     "description": "Documentation, demos and tutorials for the Amazon Vinyl player",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "type": "module",
     "scripts": {

--- a/packages/vinyl-website/package.json
+++ b/packages/vinyl-website/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-website",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "Documentation, demos and tutorials for the Amazon Vinyl player",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -32,10 +32,10 @@
         "vite": "^8.0.13"
     },
     "dependencies": {
-        "@amazon/vinyl": "^0.0.0",
-        "@amazon/vinyl-observable": "^0.0.0",
-        "@amazon/vinyl-tsx": "^0.0.0",
-        "@amazon/vinyl-util": "^0.0.0"
+        "@amazon/vinyl": "^1.0.0",
+        "@amazon/vinyl-observable": "^1.0.0",
+        "@amazon/vinyl-tsx": "^1.0.0",
+        "@amazon/vinyl-util": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"

--- a/packages/vinyl-xml/CHANGELOG.md
+++ b/packages/vinyl-xml/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))

--- a/packages/vinyl-xml/package.json
+++ b/packages/vinyl-xml/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl-xml",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "A SAX XML parser",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -66,12 +66,12 @@
         "watch:release": "tsx buildSrc/build.ts --watch --release"
     },
     "devDependencies": {
-        "@amazon/vinyl-build-utils": "^0.0.0",
-        "@amazon/vinyl-jasmine-wrapper": "^0.0.0"
+        "@amazon/vinyl-build-utils": "^1.0.0",
+        "@amazon/vinyl-jasmine-wrapper": "^1.0.0"
     },
     "dependencies": {
-        "@amazon/vinyl-util": "^0.0.0",
-        "@amazon/vinyl-validation": "^0.0.0"
+        "@amazon/vinyl-util": "^1.0.0",
+        "@amazon/vinyl-validation": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"

--- a/packages/vinyl-xml/package.json
+++ b/packages/vinyl-xml/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl-xml",
     "version": "0.0.0",
     "description": "A SAX XML parser",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "main": "./dist/index.cjs",

--- a/packages/vinyl/CHANGELOG.md
+++ b/packages/vinyl/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.0 (2026-05-21)
+
+### Bug Fixes
+
+- correct repository URL in package.json files
+  ([f5c2d6c](https://github.com/amazonmusic/vinyl/commits/f5c2d6ca1645ea84935d1c1a4434676bbb30e12d))
+- **streaming:** prevent duplicate playback on timeline misalignment
+  ([466d936](https://github.com/amazonmusic/vinyl/commits/466d93690c9845fe826b7a4c3103d54c8c27a967))

--- a/packages/vinyl/package.json
+++ b/packages/vinyl/package.json
@@ -2,7 +2,7 @@
     "name": "@amazon/vinyl",
     "version": "0.0.0",
     "description": "An HTML5 streaming media player",
-    "repository": "https://code.amazon.com/packages/Vinyl",
+    "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
     "module": "./dist/index.js",
     "main": "./dist/index.cjs",

--- a/packages/vinyl/package.json
+++ b/packages/vinyl/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@amazon/vinyl",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "An HTML5 streaming media player",
     "repository": "https://github.com/amazonmusic/vinyl",
     "license": "UNLICENSED",
@@ -88,17 +88,17 @@
         "watch:release": "tsx buildSrc/build.ts --watch --release"
     },
     "devDependencies": {
-        "@amazon/vinyl-build-utils": "^0.0.0",
+        "@amazon/vinyl-build-utils": "^1.0.0",
         "commander": "^9.5.0"
     },
     "dependencies": {
-        "@amazon/vinyl-di": "^0.0.0",
-        "@amazon/vinyl-hls-parser": "^0.0.0",
-        "@amazon/vinyl-mpd-parser": "^0.0.0",
-        "@amazon/vinyl-observable": "^0.0.0",
-        "@amazon/vinyl-transmux": "^0.0.0",
-        "@amazon/vinyl-util": "^0.0.0",
-        "@amazon/vinyl-validation": "^0.0.0"
+        "@amazon/vinyl-di": "^1.0.0",
+        "@amazon/vinyl-hls-parser": "^1.0.0",
+        "@amazon/vinyl-mpd-parser": "^1.0.0",
+        "@amazon/vinyl-observable": "^1.0.0",
+        "@amazon/vinyl-transmux": "^1.0.0",
+        "@amazon/vinyl-util": "^1.0.0",
+        "@amazon/vinyl-validation": "^1.0.0"
     },
     "browserslist": [
         "defaults, chrome 52, firefox 54, edge 15, safari 8"


### PR DESCRIPTION
ci(release): add release workflow

Trigger on pushes to the release branch. Runs npm release, versions
via lerna conventional-commits, publishes to npm using
NPM_PUBLISH_TOKEN, and syncs the version-bump commit and tags back
to main.

fix: correct repository URL in package.json files

Point root and all 15 workspace packages at github.com/amazonmusic/vinyl
instead of the internal code.amazon.com URL.