### PR TITLE
ci: add browserstack action

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -1,0 +1,27 @@
+name: BrowserStack
+
+on:
+    workflow_dispatch:
+
+concurrency:
+    group: browserstack-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .tool-versions
+                  cache: npm
+
+            - run: npm ci
+
+            - name: Run BrowserStack tests
+              env:
+                  BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+                  BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+              run: npm run test:browserstack


### PR DESCRIPTION
Adds an action to manually run Browserstack integration tests.
