### PR TITLE
fix: remove getSlotAtTime affordance

### DIFF
--- a/packages/vinyl/src/streaming/SegmentControllerImpl.ts
+++ b/packages/vinyl/src/streaming/SegmentControllerImpl.ts
@@ -429,7 +429,7 @@ export class SegmentControllerImpl
     private async _getSegment(
         time: number
     ): Promise<SegmentReference<ArrayBuffer> | null> {
-        const streamingSlot = await this.getSlotAtTime(time + 0.2)
+        const streamingSlot = await this.getSlotAtTime(time)
         if (!streamingSlot) return null
         logDebug(
             this,


### PR DESCRIPTION
When creating the initial commit, this 0.2 was an unintentional copy/paste mistake.