### PR TITLE
fix intermittent integ test error

### DIFF
--- a/packages/vinyl-util/src/global/globalRegistry.ts
+++ b/packages/vinyl-util/src/global/globalRegistry.ts
@@ -6,6 +6,7 @@
 import { isDisposable } from '@/core/disposable'
 import { IllegalStateError } from '@/error/IllegalStateError'
 import { remove } from '@/util/collection/array'
+import type { Maybe } from '@/util/type'
 
 /**
  * Manages global initializers.
@@ -95,11 +96,25 @@ export interface GlobalRef<T> {
     initialize(): void
 }
 
+/**
+ * When set, GlobalRefImpl records a stack trace each time it is initialized,
+ * so a later "Cannot call when initialized" error can include the stack of
+ * whoever last touched the ref. Used to diagnose async leakage between specs.
+ *
+ * Tests opt in via setGlobalRefDebug(true).
+ */
+let globalRefDebug = false
+
+export function setGlobalRefDebug(enabled: boolean): void {
+    globalRefDebug = enabled
+}
+
 export class GlobalRefImpl<T> implements GlobalRef<T> {
     private _value: T | undefined
     private _initialized = false
     private constructing = false
     private initializer: () => T
+    private lastInitStack: Maybe<string> = null
 
     constructor(private readonly defaultInitializer: () => T) {
         this.initializer = defaultInitializer
@@ -119,6 +134,7 @@ export class GlobalRefImpl<T> implements GlobalRef<T> {
         if (!this._initialized) return
         this.assertNotConstructing()
         this._initialized = false
+        this.lastInitStack = null
         if (isDisposable(this._value)) {
             this._value.dispose()
         }
@@ -137,6 +153,9 @@ export class GlobalRefImpl<T> implements GlobalRef<T> {
         }
         this.constructing = false
         this._initialized = true
+        if (globalRefDebug) {
+            this.lastInitStack = new Error('globalRef initialized').stack
+        }
     }
 
     set(newInitializer: (previousInitializer: () => T) => T): GlobalRef<T> {
@@ -155,8 +174,12 @@ export class GlobalRefImpl<T> implements GlobalRef<T> {
     }
 
     private assertNotInitialized() {
-        if (this._initialized)
-            throw new IllegalStateError('Cannot call when initialized')
+        if (this._initialized) {
+            const detail = this.lastInitStack
+                ? `\nLast initialized at:\n${this.lastInitStack}`
+                : ''
+            throw new IllegalStateError(`Cannot call when initialized${detail}`)
+        }
     }
 
     private assertNotConstructing() {

--- a/packages/vinyl-util/test/unit/global/globalRegistry.test.ts
+++ b/packages/vinyl-util/test/unit/global/globalRegistry.test.ts
@@ -10,6 +10,7 @@ import {
     GlobalRefImpl,
     GlobalRegistry,
     IllegalStateError,
+    setGlobalRefDebug,
 } from '@amazon/vinyl-util'
 import createSpy = jasmine.createSpy
 import objectContaining = jasmine.objectContaining
@@ -202,6 +203,68 @@ describe('getGlobalRegistry', () => {
                     expect(() => ref.initialize()).toThrowError(
                         IllegalStateError
                     )
+                })
+            })
+        })
+
+        describe('setGlobalRefDebug', () => {
+            afterEach(() => {
+                setGlobalRefDebug(false)
+            })
+
+            describe('when disabled (default)', () => {
+                it('throws without a stack detail when set is called after initialize', () => {
+                    const ref = new GlobalRefImpl(() => 1)
+                    ref.initialize()
+                    expect(() => ref.set(() => 2)).toThrowError(
+                        IllegalStateError,
+                        'Cannot call when initialized'
+                    )
+                })
+            })
+
+            describe('when enabled', () => {
+                it('includes the initialization stack in the error message', () => {
+                    setGlobalRefDebug(true)
+                    const ref = new GlobalRefImpl(() => 1)
+                    ref.initialize()
+                    expect(() => ref.set(() => 2)).toThrowError(
+                        IllegalStateError,
+                        /Cannot call when initialized\nLast initialized at:\n[\s\S]*globalRef initialized/
+                    )
+                })
+
+                it('clears the recorded stack on reset so re-init does not leak the prior stack', () => {
+                    setGlobalRefDebug(true)
+                    const ref = new GlobalRefImpl(() => 1)
+                    ref.initialize()
+                    ref.reset()
+                    setGlobalRefDebug(false)
+                    ref.initialize()
+                    expect(() => ref.set(() => 2)).toThrowError(
+                        IllegalStateError,
+                        // No "Last initialized at:" detail because debug was off at the second initialize.
+                        /^Cannot call when initialized$/
+                    )
+                })
+
+                it('refreshes the recorded stack on each initialize', () => {
+                    setGlobalRefDebug(true)
+                    const ref = new GlobalRefImpl(() => 1)
+                    const firstInit = () => ref.initialize()
+                    firstInit()
+                    ref.reset()
+                    const secondInit = () => ref.initialize()
+                    secondInit()
+                    let captured: Error | undefined
+                    try {
+                        ref.set(() => 2)
+                    } catch (e) {
+                        captured = e as Error
+                    }
+                    expect(captured).toBeDefined()
+                    expect(captured!.message).toContain('secondInit')
+                    expect(captured!.message).not.toContain('firstInit')
                 })
             })
         })

--- a/packages/vinyl/src/streaming/SegmentControllerImpl.ts
+++ b/packages/vinyl/src/streaming/SegmentControllerImpl.ts
@@ -6,7 +6,6 @@
 import type { Mutable, Unsubscribe } from '@amazon/vinyl-util'
 import {
     Abort,
-    AbortError,
     clone,
     closeTo,
     createDisposer,
@@ -343,10 +342,13 @@ export class SegmentControllerImpl
                             this.ended = true
                             return
                         }
-                        await Promise.all([
-                            slot.initData.request(),
-                            slot.data.request(),
-                        ])
+                        await withAbort(
+                            Promise.all([
+                                slot.initData.request(),
+                                slot.data.request(),
+                            ]),
+                            this.abort
+                        )
                     },
                     this.contentType,
                     this.prefetchingPriority
@@ -586,7 +588,7 @@ export class SegmentControllerImpl
             time,
             SEGMENT_START_AFFORDANCE
         )
-        if (this.disposed) throw new AbortError()
+        this.abort.throwIfAborted()
         this.streamingQuality = segment?.quality ?? null
         if (!segment) return null
 

--- a/packages/vinyl/test/unit/setup.ts
+++ b/packages/vinyl/test/unit/setup.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getGlobalRegistry } from '@amazon/vinyl-util'
+import { getGlobalRegistry, setGlobalRefDebug } from '@amazon/vinyl-util'
 import {
     addCustomMatchers,
     ConsoleReporter,
@@ -13,6 +13,9 @@ import { RestApiReporter } from '@amazon/vinyl-util/testUtil'
 import { initializeFrequencyAnalyzer } from '@amazon/vinyl/vinylTestUtil'
 
 addCustomMatchers()
+
+// Diagnostic: GlobalRefImpl records the stack
+setGlobalRefDebug(true)
 
 // Configured here instead of the jasmine.config.json to work with both ts-node and the html
 // test runner.


### PR DESCRIPTION
Fixes intermittent integ test errors where a failed prefetched segment was leaking into neighbor tests, causing them to fail due to an attempt at re-initializing globals.

test(SegmentController): add withAbort to segment prefetch

integration tests, on rare occassion, would fail because a segment
prefetch failure could leak into the next test.

Adds a safety to the prefetch to throw with a silent abort error
when disposed.

feat(vinyl-util): capture init stack on GlobalRef when debug is enabled

setGlobalRefDebug(true) makes GlobalRefImpl record the initialization
stack and include it in the "Cannot call when initialized" error, so
async leakage between specs can be traced to the offending caller.