### PR TITLE
Feat/maxbandwidth

### DIFF
--- a/buildSrc/writePackageJsonExports.ts
+++ b/buildSrc/writePackageJsonExports.ts
@@ -58,6 +58,27 @@ function writePackageJsonExports() {
             const exportJson: any = {}
             exportsJson[exportKey] = exportJson
 
+            // development condition resolves to TS source so tests and tsc (via
+            // tsconfig customConditions) can resolve cross-package imports without a build.
+            // Convention: '.' -> src/index.ts; './X' -> src/X, test/X, or X under the package root.
+            // Must come before `types@>=N` since conditional exports are first-match-wins;
+            // otherwise the `types` condition (always passed by tsc) would short-circuit to dist.
+            const sourceCandidates = exportDirRel
+                ? [
+                      `${packageDir}/src/${exportDirRel}/index.ts`,
+                      `${packageDir}/test/${exportDirRel}/index.ts`,
+                      `${packageDir}/${exportDirRel}/index.ts`,
+                  ]
+                : [`${packageDir}/src/index.ts`]
+            const sourcePath = sourceCandidates.find((p) => fs.existsSync(p))
+            if (sourcePath) {
+                exportJson.development = `./${path.relative(packageDir, sourcePath)}`
+            } else {
+                console.warn(
+                    `No source found for ${packageDir} export ${exportKey}; tried: ${sourceCandidates.join(', ')}`
+                )
+            }
+
             // Check type declarations, sorted by version descending so keys are inserted in the right order.
             const dtsIndexPaths = glob.sync(`${exportDir}/types/*/index.d.ts`)
             dtsIndexPaths.sort((a, b) => {
@@ -91,25 +112,7 @@ function writePackageJsonExports() {
                 }
             }
 
-            // development condition resolves to TS source so tests can run without a build.
-            // Convention: '.' -> src/index.ts; './X' -> src/X, test/X, or X under the package root.
-            const sourceCandidates = exportDirRel
-                ? [
-                      `${packageDir}/src/${exportDirRel}/index.ts`,
-                      `${packageDir}/test/${exportDirRel}/index.ts`,
-                      `${packageDir}/${exportDirRel}/index.ts`,
-                  ]
-                : [`${packageDir}/src/index.ts`]
-            const sourcePath = sourceCandidates.find((p) => fs.existsSync(p))
-            if (sourcePath) {
-                exportJson.development = `./${path.relative(packageDir, sourcePath)}`
-            } else {
-                console.warn(
-                    `No source found for ${packageDir} export ${exportKey}; tried: ${sourceCandidates.join(', ')}`
-                )
-            }
-
-            // require/import must come after @types and development
+            // require/import must come after development and @types.
             const commonJsPath = path.resolve(exportDir, 'index.cjs')
             if (fs.existsSync(commonJsPath)) {
                 exportJson.require = `./${path.relative(packageDir, commonJsPath)}`

--- a/packages/vinyl-cache-manager/package.json
+++ b/packages/vinyl-cache-manager/package.json
@@ -42,9 +42,9 @@
     },
     "exports": {
         ".": {
+            "development": "./src/index.ts",
             "types@>=5.4": "./dist/types/current/index.d.ts",
             "types@>=4.7": "./dist/types/ts4.7/index.d.ts",
-            "development": "./src/index.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.js"
         }

--- a/packages/vinyl-di/package.json
+++ b/packages/vinyl-di/package.json
@@ -42,9 +42,9 @@
     },
     "exports": {
         ".": {
+            "development": "./src/index.ts",
             "types@>=5.4": "./dist/types/current/index.d.ts",
             "types@>=4.7": "./dist/types/ts4.7/index.d.ts",
-            "development": "./src/index.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.js"
         }

--- a/packages/vinyl-hls-parser/package.json
+++ b/packages/vinyl-hls-parser/package.json
@@ -55,16 +55,16 @@
     },
     "exports": {
         ".": {
+            "development": "./src/index.ts",
             "types@>=5.4": "./dist/types/current/index.d.ts",
             "types@>=4.7": "./dist/types/ts4.7/index.d.ts",
-            "development": "./src/index.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.js"
         },
         "./hlsTestAssets": {
+            "development": "./test/hlsTestAssets/index.ts",
             "types@>=5.4": "./dist/hlsTestAssets/types/current/index.d.ts",
             "types@>=4.7": "./dist/hlsTestAssets/types/ts4.7/index.d.ts",
-            "development": "./test/hlsTestAssets/index.ts",
             "import": "./dist/hlsTestAssets/index.js"
         }
     },

--- a/packages/vinyl-mpd-parser/package.json
+++ b/packages/vinyl-mpd-parser/package.json
@@ -55,16 +55,16 @@
     },
     "exports": {
         ".": {
+            "development": "./src/index.ts",
             "types@>=5.4": "./dist/types/current/index.d.ts",
             "types@>=4.7": "./dist/types/ts4.7/index.d.ts",
-            "development": "./src/index.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.js"
         },
         "./dashTestAssets": {
+            "development": "./test/dashTestAssets/index.ts",
             "types@>=5.4": "./dist/dashTestAssets/types/current/index.d.ts",
             "types@>=4.7": "./dist/dashTestAssets/types/ts4.7/index.d.ts",
-            "development": "./test/dashTestAssets/index.ts",
             "import": "./dist/dashTestAssets/index.js"
         }
     },

--- a/packages/vinyl-observable/package.json
+++ b/packages/vinyl-observable/package.json
@@ -42,9 +42,9 @@
     },
     "exports": {
         ".": {
+            "development": "./src/index.ts",
             "types@>=5.4": "./dist/types/current/index.d.ts",
             "types@>=4.7": "./dist/types/ts4.7/index.d.ts",
-            "development": "./src/index.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.js"
         }

--- a/packages/vinyl-transmux/package.json
+++ b/packages/vinyl-transmux/package.json
@@ -43,9 +43,9 @@
     },
     "exports": {
         ".": {
+            "development": "./src/index.ts",
             "types@>=5.4": "./dist/types/current/index.d.ts",
             "types@>=4.7": "./dist/types/ts4.7/index.d.ts",
-            "development": "./src/index.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.js"
         }

--- a/packages/vinyl-tsx/package.json
+++ b/packages/vinyl-tsx/package.json
@@ -42,9 +42,9 @@
     },
     "exports": {
         ".": {
+            "development": "./src/index.ts",
             "types@>=5.4": "./dist/types/current/index.d.ts",
             "types@>=4.7": "./dist/types/ts4.7/index.d.ts",
-            "development": "./src/index.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.js"
         }

--- a/packages/vinyl-util/package.json
+++ b/packages/vinyl-util/package.json
@@ -67,16 +67,16 @@
     },
     "exports": {
         ".": {
+            "development": "./src/index.ts",
             "types@>=5.4": "./dist/types/current/index.d.ts",
             "types@>=4.7": "./dist/types/ts4.7/index.d.ts",
-            "development": "./src/index.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.js"
         },
         "./testUtil": {
+            "development": "./test/testUtil/index.ts",
             "types@>=5.4": "./dist/testUtil/types/current/index.d.ts",
             "types@>=4.7": "./dist/testUtil/types/ts4.7/index.d.ts",
-            "development": "./test/testUtil/index.ts",
             "import": "./dist/testUtil/index.js"
         },
         "./polyfill": {
@@ -84,9 +84,9 @@
             "import": "./dist/polyfill/index.js"
         },
         "./browserTestUtil": {
+            "development": "./test/browserTestUtil/index.ts",
             "types@>=5.4": "./dist/browserTestUtil/types/current/index.d.ts",
             "types@>=4.7": "./dist/browserTestUtil/types/ts4.7/index.d.ts",
-            "development": "./test/browserTestUtil/index.ts",
             "import": "./dist/browserTestUtil/index.js"
         }
     },

--- a/packages/vinyl-validation/package.json
+++ b/packages/vinyl-validation/package.json
@@ -43,9 +43,9 @@
     },
     "exports": {
         ".": {
+            "development": "./src/index.ts",
             "types@>=5.4": "./dist/types/current/index.d.ts",
             "types@>=4.7": "./dist/types/ts4.7/index.d.ts",
-            "development": "./src/index.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.js"
         }

--- a/packages/vinyl-xml/package.json
+++ b/packages/vinyl-xml/package.json
@@ -42,9 +42,9 @@
     },
     "exports": {
         ".": {
+            "development": "./src/index.ts",
             "types@>=5.4": "./dist/types/current/index.d.ts",
             "types@>=4.7": "./dist/types/ts4.7/index.d.ts",
-            "development": "./src/index.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.js"
         }

--- a/packages/vinyl/docs/USAGE.md
+++ b/packages/vinyl/docs/USAGE.md
@@ -397,3 +397,36 @@ player.on('playbackQualityChange', (event) => {
     console.log('Playback quality changed:', event.previous, '→', event.current)
 })
 ```
+
+## Adaptive Bitrate Configuration
+
+Adaptive bitrate behavior is configured through `player.configure({ abr })` and
+can be changed at any time; the timeline is re-evaluated on the next quality
+selection.
+
+### Capping Bandwidth
+
+Use `abr.maxBandwidth` to cap the maximum per-second bandwidth (in bits per
+second) of any selectable quality. This is a soft cap: if no qualities fit
+within the limit, the lowest-bandwidth quality is selected so playback remains
+possible. Setting `maxBandwidth` to `0` therefore pins playback to the lowest
+available quality.
+
+`maxBandwidth` has no effect when `strategy` is `AbrStrategy.LOWEST` or
+`AbrStrategy.HIGHEST`, since those strategies pin selection regardless of
+bandwidth.
+
+```typescript
+// Limit selectable qualities to 1.5 Mbps or less.
+player.configure({
+    abr: {
+        maxBandwidth: 1_500_000,
+    },
+})
+
+// Pin to the lowest available quality.
+player.configure({ abr: { maxBandwidth: 0 } })
+
+// Remove the cap.
+player.configure({ abr: { maxBandwidth: null } })
+```

--- a/packages/vinyl/package.json
+++ b/packages/vinyl/package.json
@@ -55,16 +55,16 @@
     },
     "exports": {
         ".": {
+            "development": "./src/index.ts",
             "types@>=5.4": "./dist/types/current/index.d.ts",
             "types@>=4.7": "./dist/types/ts4.7/index.d.ts",
-            "development": "./src/index.ts",
             "require": "./dist/index.cjs",
             "import": "./dist/index.js"
         },
         "./vinylTestUtil": {
+            "development": "./test/vinylTestUtil/index.ts",
             "types@>=5.4": "./dist/vinylTestUtil/types/current/index.d.ts",
             "types@>=4.7": "./dist/vinylTestUtil/types/ts4.7/index.d.ts",
-            "development": "./test/vinylTestUtil/index.ts",
             "import": "./dist/vinylTestUtil/index.js"
         }
     },

--- a/packages/vinyl/src/streaming/abr/QualitySelectorImpl.ts
+++ b/packages/vinyl/src/streaming/abr/QualitySelectorImpl.ts
@@ -12,6 +12,7 @@ import {
     getNetworkMetrics,
     type LogTarget,
     lerp,
+    type Maybe,
 } from '@amazon/vinyl-util'
 import {
     boolean,
@@ -77,6 +78,21 @@ export interface QualitySelectorImplOptions {
      * Default: false
      */
     readonly restrictDecoderChangeOnAudioAbrUp?: boolean
+
+    /**
+     * Maximum bandwidth in bits per second a quality may use to be selectable.
+     *
+     * Soft cap: if no qualities fit within the limit (including when set to 0),
+     * the quality with the lowest bandwidth is selected so playback is still
+     * possible.
+     *
+     * Has no effect when {@link strategy} is {@link AbrStrategy.LOWEST} or
+     * {@link AbrStrategy.HIGHEST}, since those strategies pin the selection
+     * regardless of bandwidth.
+     *
+     * Default: null (no limit).
+     */
+    readonly maxBandwidth?: Maybe<number>
 }
 
 export enum AbrStrategy {
@@ -112,6 +128,7 @@ export const qualitySelectorImplOptionsValidator: ObjectSchema<QualitySelectorIm
         bandwidthMultiplierLow: number().optional(),
         bandwidthMultiplierHigh: number().optional(),
         restrictDecoderChangeOnAudioAbrUp: boolean().optional(),
+        maxBandwidth: number().maybe().optional(),
     })
 
 export const defaultQualitySelectorImplOptions = {
@@ -121,6 +138,7 @@ export const defaultQualitySelectorImplOptions = {
     bandwidthMultiplierLow: 0.4,
     bandwidthMultiplierHigh: 0.9,
     restrictDecoderChangeOnAudioAbrUp: false,
+    maxBandwidth: null,
 } as const satisfies QualitySelectorImplOptions
 
 export interface QualitySelectorImplDeps {
@@ -164,6 +182,7 @@ export class QualitySelectorImpl
             bandwidthMultiplierLow,
             bandwidthMultiplierHigh,
             restrictDecoderChangeOnAudioAbrUp,
+            maxBandwidth,
         } = this.options
         const previousQuality = prefetchState.previousQuality
         // previousIndex will be -1 if the previously playing quality is not within the current qualities list.
@@ -202,10 +221,15 @@ export class QualitySelectorImpl
         // Choose bandwidth based on pessimistic network information.
         // If the track is active, take the lesser of the latest recorded bandwidth stat and the weighted
         // average to allow for fast ABR-down in variable conditions.
-        const bandwidth =
+        let bandwidth =
             (prefetchState.active
                 ? Math.min(bandwidthEstimate.ewmaLow, bandwidthEstimate.latest)
                 : bandwidthEstimate.ewmaLow) * bandwidthMultiplier
+
+        // Apply the maxBandwidth cap as a soft upper bound on the bandwidth budget.
+        if (maxBandwidth != null && maxBandwidth < bandwidth) {
+            bandwidth = maxBandwidth
+        }
 
         let restrictDecoderId: string | null = null
         let restrictSwitchingGroupIds: readonly string[] | null = null

--- a/packages/vinyl/test/unit/streaming/abr/QualitySelectorImpl.test.ts
+++ b/packages/vinyl/test/unit/streaming/abr/QualitySelectorImpl.test.ts
@@ -733,6 +733,91 @@ describe('QualitySelectorImpl', () => {
         })
     })
 
+    describe('maxBandwidth', () => {
+        const qualities: readonly MediaQualityMetadata[] = [
+            {
+                ...createEmptyMediaQualityMetadata(),
+                bandwidth: 1000,
+                bandwidthTotal: 1000,
+                qualityId: '0',
+            },
+            {
+                ...createEmptyMediaQualityMetadata(),
+                bandwidth: 500,
+                bandwidthTotal: 500,
+                qualityId: '1',
+            },
+            {
+                ...createEmptyMediaQualityMetadata(),
+                bandwidth: 100,
+                bandwidthTotal: 100,
+                qualityId: '2',
+            },
+        ] as const
+
+        const prefetchState: PrefetchState = {
+            fetchedTime: 0,
+            previousQuality: null,
+            active: false,
+        }
+
+        beforeEach(() => {
+            // Plenty of bandwidth for the highest quality.
+            metrics.estimatedDownlinkBandwidth.ewmaLow = 5000
+        })
+
+        it('caps the selectable quality to the configured bandwidth', () => {
+            options.value = { ...options.value, maxBandwidth: 500 }
+            // Highest quality at or below the cap is index 1 (500).
+            expect(selector.selectQuality(qualities, prefetchState)).toEqual(1)
+        })
+
+        it('falls back to the lowest quality when all exceed the cap', () => {
+            options.value = { ...options.value, maxBandwidth: 50 }
+            // No quality fits — selectQuality falls back to the last (lowest) entry.
+            expect(selector.selectQuality(qualities, prefetchState)).toEqual(2)
+        })
+
+        it('pins to the lowest quality when set to 0', () => {
+            options.value = { ...options.value, maxBandwidth: 0 }
+            expect(selector.selectQuality(qualities, prefetchState)).toEqual(2)
+        })
+
+        it('treats null as no cap', () => {
+            options.value = { ...options.value, maxBandwidth: null }
+            expect(selector.selectQuality(qualities, prefetchState)).toEqual(0)
+        })
+
+        it('does not raise the bandwidth budget above the network estimate', () => {
+            // Network estimate is well below the cap; cap should not raise it.
+            metrics.estimatedDownlinkBandwidth.ewmaLow = 600
+            options.value = { ...options.value, maxBandwidth: 100_000 }
+            expect(selector.selectQuality(qualities, prefetchState)).toEqual(1)
+        })
+
+        it('has no effect when strategy is LOWEST', () => {
+            options.value = {
+                ...options.value,
+                strategy: AbrStrategy.LOWEST,
+                maxBandwidth: 100_000,
+            }
+            // LOWEST always returns the last index, regardless of the cap.
+            expect(selector.selectQuality(qualities, prefetchState)).toEqual(
+                qualities.length - 1
+            )
+        })
+
+        it('has no effect when strategy is HIGHEST', () => {
+            options.value = {
+                ...options.value,
+                strategy: AbrStrategy.HIGHEST,
+                maxBandwidth: 50,
+            }
+            // HIGHEST always returns 0, regardless of the cap.
+            expect(selector.selectQuality(qualities, prefetchState)).toEqual(0)
+        })
+    })
+
     describe('toString', () => {
         it('returns a string', () => {
             expect(selector.toString()).toContain('QualitySelectorImpl')

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -33,7 +33,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    "types": ["node"],                        /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"],                                   /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
Adds `maxBandwidth` to QualitySelectorImplOptions, surfaced as a soft
filter in the default media timeline transformer. Qualities above the
limit are dropped; if all exceed it (including when set to 0), the
lowest-bandwidth quality is kept so playback stays possible. The filter
runs last in the transformer chain and is reactive to configure() calls.

Also reorders the generated package.json `exports` so that `development`
precedes `types@>=N`. Conditional exports are first-match-wins, so the
prior order short-circuited tsc to dist/types and defeated the
`customConditions: ["development"]` setting in tsconfig.