### PR TITLE
Refactor/duration

### DIFF
--- a/packages/vinyl/src/streaming/MediaTimeline.ts
+++ b/packages/vinyl/src/streaming/MediaTimeline.ts
@@ -49,9 +49,10 @@ export interface MediaTimeline {
 
     /**
      * The total duration of the media, in seconds.
-     * Returns null if duration cannot be determined.
+     * Returns `Infinity` for live streams.
+     * Rejects when there are no segments to derive a duration from.
      */
-    getDuration?(): Promise<number | null>
+    getDuration(): Promise<number>
 }
 
 /**

--- a/packages/vinyl/src/streaming/SegmentController.ts
+++ b/packages/vinyl/src/streaming/SegmentController.ts
@@ -68,12 +68,6 @@ export interface ReadonlySegmentController extends ReadonlyEventHost<SegmentCont
     readonly streamingQuality: MediaQualityMetadata | null
 
     /**
-     * The duration of the media, in seconds.
-     * Returns null if duration cannot be determined.
-     */
-    getDuration(): Promise<number | null>
-
-    /**
      * Returns a Promise for a segment covering the given time, with quality chosen by
      * the configured `QualitySelector`. Resolves to `null` if no media exists at that
      * time. Negative `time` values are clamped to `0`.

--- a/packages/vinyl/src/streaming/SegmentControllerImpl.ts
+++ b/packages/vinyl/src/streaming/SegmentControllerImpl.ts
@@ -182,15 +182,6 @@ export class SegmentControllerImpl
         return this._error
     }
 
-    async getDuration(): Promise<number | null> {
-        const timeline = await this.deps.mediaTimelineTransformed.value
-        if (timeline.getDuration) return timeline.getDuration()
-        const periods = timeline.periods
-        if (periods.length === 0) return null
-        const last = periods[periods.length - 1]
-        return last.endTime === Infinity ? null : last.endTime
-    }
-
     /**
      * Gets the period at the given time, using a cache for the last returned period.
      */

--- a/packages/vinyl/src/streaming/buffering/BufferingController.ts
+++ b/packages/vinyl/src/streaming/buffering/BufferingController.ts
@@ -26,19 +26,11 @@ import type { ReadonlyPlaybackController } from '../../playback/ReadonlyPlayback
 import type { SourceBufferController } from './SourceBufferController'
 import type { ReadonlySegmentController } from '../SegmentController'
 import type { SegmentReference } from '../SegmentReference'
-import { LIVE_DURATION } from '../../playback/PlaybackController'
 import type { BasicErrorEvent } from '../../event/BasicErrorEvent'
 import type { ChangeEvent } from '../../event/ChangeEvent'
 import type { ContentType, MediaQualityMetadata } from '../MediaQualityMetadata'
 import { type MediaSourceController } from './MediaSourceController'
 import { SEGMENT_START_AFFORDANCE } from '../SegmentController'
-
-/**
- * Chrome 52 has decoding errors when duration is set to the mediaPresentationDuration.
- * Adds a slight padding as a workaround.
- * @private
- */
-export const DURATION_PADDING = 0.1
 
 /**
  * The interval to throttle polling the buffer.
@@ -280,7 +272,6 @@ export class BufferingControllerImpl
 
         const onMediaSourceOpen = () => {
             logDebug(this, 'media source opened')
-            this.refreshDuration()
             this.pollBufferImmediate()
         }
         if (this.mediaSourceOpen) {
@@ -291,7 +282,6 @@ export class BufferingControllerImpl
         add(
             this.segmentController.on('change', () => {
                 this.reopen = true
-                this.refreshDuration()
                 this.pollBufferImmediate()
             })
         )
@@ -323,21 +313,6 @@ export class BufferingControllerImpl
      */
     get busy(): boolean {
         return this.queue.running > 0
-    }
-
-    /**
-     * Enqueues a duration update.
-     */
-    private refreshDuration() {
-        this.sourceBufferController!.enqueue(async () => {
-            if (!this.mediaSourceOpen) return // Cannot set duration when media source is not open.
-            const duration = await this.segmentController.getDuration()
-            // For live streams, set the duration to LIVE_DURATION; not all browsers support +Infinity duration.
-            const newDuration =
-                duration == null ? LIVE_DURATION : duration + DURATION_PADDING
-            logDebug(this, `setting duration: ${newDuration}`)
-            this.mediaSourceController.duration = newDuration
-        }).catch(this.handleError)
     }
 
     /**

--- a/packages/vinyl/src/streaming/buffering/MediaSourceController.ts
+++ b/packages/vinyl/src/streaming/buffering/MediaSourceController.ts
@@ -5,12 +5,14 @@
 
 import {
     type AnyRecord,
+    closeTo,
     createDisposer,
     type Disposable,
     DomEventHost,
     ErrorLevel,
     ErrorOrigin,
     EventHostImpl,
+    isSilentError,
     type Json,
     logDebug,
     type LogTarget,
@@ -20,9 +22,20 @@ import {
     toJson,
     toLowerCase,
 } from '@amazon/vinyl-util'
+import type { ObservableValue } from '@amazon/vinyl-observable'
 import type { ContentTypesValue } from '../ContentTypesValue'
 import type { BasicErrorEvent } from '../../event/BasicErrorEvent'
 import type { ContentType } from '../MediaQualityMetadata'
+import type { MediaTimeline } from '../MediaTimeline'
+import { LIVE_DURATION } from '../../playback/PlaybackController'
+import { nextSourceBufferIdle } from '../../util/media/sourceBuffer'
+
+/**
+ * Chrome 52 has decoding errors when duration is set to the mediaPresentationDuration.
+ * Adds a slight padding as a workaround.
+ * @private
+ */
+export const DURATION_PADDING = 0.1
 
 export interface SourceBufferRef extends Disposable {
     /**
@@ -48,7 +61,8 @@ export interface MediaSourceControllerEventMap {
     readonly sourceOpen: AnyRecord
 
     /**
-     * All source buffers have been created and data may be appended.
+     * All source buffers have been created, the media source duration has been set, and data
+     * may be appended.
      */
     readonly readyToAppend: AnyRecord
 
@@ -65,22 +79,12 @@ export interface ReadonlyMediaSourceController extends ReadonlyEventHost<MediaSo
     readonly readyState: ReadyState
 
     /**
-     * Gets the media source's duration.
-     */
-    readonly duration: number
-
-    /**
      * True if all source buffers have been created and data may be appended.
      */
     readonly readyToAppend: boolean
 }
 
 export interface MediaSourceController extends ReadonlyMediaSourceController {
-    /**
-     * Sets/gets the media source's duration.
-     */
-    duration: number
-
     /**
      * Constructs a new SourceBuffer with the given content type and mime type.
      */
@@ -111,6 +115,11 @@ export interface MediaSourceControllerImplDeps {
      * Provides the streams that must be created before appending.
      */
     readonly contentTypesValue: ContentTypesValue
+
+    /**
+     * The media timeline used to determine duration.
+     */
+    readonly mediaTimelineTransformed: ObservableValue<Promise<MediaTimeline>>
 }
 
 export class MediaSourceControllerImpl
@@ -121,13 +130,20 @@ export class MediaSourceControllerImpl
         return 'MediaSourceControllerImpl'
     }
 
-    private sourceBufferCount = 0
+    private readonly sourceBuffers = new Set<SourceBuffer>()
 
     private readonly mediaSource: MediaSource
     private readonly disposer = createDisposer()
     private contentTypes: ReadonlySet<ContentType> | null = null
+    private durationSet = false
 
-    constructor(deps: MediaSourceControllerImplDeps) {
+    /**
+     * Token for the in-flight duration update; used to discard stale results when
+     * the timeline changes or the source closes mid-fetch.
+     */
+    private durationToken = 0
+
+    constructor(private readonly deps: MediaSourceControllerImplDeps) {
         super()
         this.mediaSource = deps.mediaSourceFactory()
         this.initializeEvents()
@@ -139,21 +155,33 @@ export class MediaSourceControllerImpl
                         this.contentTypes = contentTypes
                         this.checkReady()
                     })
-                    .catch((error) => {
-                        this.dispatch('error', {
-                            target: this,
-                            error: error,
-                        })
-                    })
+                    .catch(this.errorHandler)
             })
         )
     }
+
+    private get sourceBufferCount(): number {
+        return this.sourceBuffers.size
+    }
+
+    private readonly errorHandler = (error: any) => {
+        if (isSilentError(error)) return
+        this.dispatch('error', {
+            target: this,
+            error,
+        })
+    }
+
+    /**
+     * Subscription to mediaTimelineTransformed; only attached while the media source is open
+     * so the timeline pipeline isn't forced to evaluate before the source has opened.
+     */
+    private timelineSub: (() => void) | null = null
 
     private initializeEvents(): void {
         const domEvents = new DomEventHost<MediaSourceEventMap>(
             this.mediaSource
         )
-        // Re-dispatch html media element events exposed on the playback controller as empty events.
         for (const key of [
             'sourceClose',
             'sourceOpen',
@@ -161,14 +189,43 @@ export class MediaSourceControllerImpl
         ] as const) {
             domEvents.on(toLowerCase(key), () => this.dispatch(key, {}))
         }
+        this.timelineSub = this.deps.mediaTimelineTransformed.onData(() => {
+            this.refreshDuration().catch(this.errorHandler)
+        })
+        this.on('sourceOpen', () => {
+            this.refreshDuration().catch(this.errorHandler)
+        })
+        this.on('sourceClose', () => {
+            this.durationSet = false
+            ++this.durationToken
+        })
     }
 
-    get duration(): number {
-        return this.mediaSource.duration
-    }
-
-    set duration(value: number) {
+    /**
+     * Sets the duration on the media source from the current media timeline.
+     * Live streams use LIVE_DURATION since not all browsers support +Infinity duration.
+     *
+     * MSE throws InvalidStateError if duration is set while any source buffer is updating,
+     * so we wait for all tracked source buffers to be idle first.
+     */
+    private async refreshDuration(): Promise<void> {
+        const timelinePromise = this.deps.mediaTimelineTransformed.value
+        const token = ++this.durationToken
+        const timeline = await timelinePromise
+        const duration = await timeline.getDuration()
+        const value =
+            duration === Infinity ? LIVE_DURATION : duration + DURATION_PADDING
+        await Promise.all(Array.from(this.sourceBuffers, nextSourceBufferIdle))
+        if (
+            token !== this.durationToken ||
+            this.mediaSource.readyState !== 'open' ||
+            closeTo(this.mediaSource.duration, value, 0.1)
+        )
+            return
+        logDebug(this, `setting duration: ${value}`)
         this.mediaSource.duration = value
+        this.durationSet = true
+        this.checkReady()
     }
 
     get readyState(): ReadyState {
@@ -196,7 +253,7 @@ export class MediaSourceControllerImpl
             throw new MediaSourceError('error creating source buffer', error)
         }
         sourceBuffer.mode = 'sequence'
-        ++this.sourceBufferCount
+        this.sourceBuffers.add(sourceBuffer)
         this.checkReady()
 
         const dispose = () => {
@@ -208,7 +265,7 @@ export class MediaSourceControllerImpl
             if (mediaSource.readyState !== 'closed') {
                 mediaSource.removeSourceBuffer(sourceBuffer)
             }
-            --this.sourceBufferCount
+            this.sourceBuffers.delete(sourceBuffer)
         }
 
         return {
@@ -218,7 +275,8 @@ export class MediaSourceControllerImpl
     }
 
     /**
-     * Emits a 'readyToAppend' event if all source buffers have been created.
+     * Emits a 'readyToAppend' event if all source buffers have been created and the duration
+     * has been applied to the media source.
      */
     private readonly checkReady = () => {
         if (this.readyToAppend) this.dispatch('readyToAppend', {})
@@ -234,11 +292,16 @@ export class MediaSourceControllerImpl
     }
 
     get readyToAppend(): boolean {
-        return this.contentTypes?.size === this.sourceBufferCount
+        return (
+            this.durationSet &&
+            this.contentTypes?.size === this.sourceBufferCount
+        )
     }
 
     dispose() {
         super.dispose()
+        this.timelineSub?.()
+        this.timelineSub = null
         this.disposer.dispose()
     }
 }

--- a/packages/vinyl/src/track/dash/util/mpd.ts
+++ b/packages/vinyl/src/track/dash/util/mpd.ts
@@ -179,11 +179,20 @@ export function flattenRepresentations(
 
 /**
  * Calculates the manifest duration, either from the mediaPresentationDuration or the last period end time.
- * @param manifest
+ * Returns `Infinity` for live (dynamic) presentations.
+ * Throws if duration cannot be determined.
  */
-export function calculateDuration(manifest: DashManifest): number | null {
+export function calculateDuration(manifest: DashManifest): number {
+    if (manifest.MPD.type === 'dynamic') return Infinity
     const mpdDuration = manifest.MPD.mediaPresentationDuration
     if (mpdDuration != null) return mpdDuration
-    // If mediaPresentationDuration is not present, take the end time of the last period.
-    return calculatePeriodEnd(last(manifest.MPD.Period)!)
+    const lastPeriod = last(manifest.MPD.Period)
+    if (!lastPeriod) {
+        throw new Error('Unable to determine manifest duration: no periods')
+    }
+    const end = calculatePeriodEnd(lastPeriod)
+    if (end == null) {
+        throw new Error('Unable to determine manifest duration')
+    }
+    return end
 }

--- a/packages/vinyl/src/track/hls/buildHlsMediaTimeline.ts
+++ b/packages/vinyl/src/track/hls/buildHlsMediaTimeline.ts
@@ -175,17 +175,22 @@ export function buildHlsMediaTimeline(
         minBufferTime: DEFAULT_MIN_BUFFER_TIME,
         async getDuration() {
             if (cachedDuration != null) return cachedDuration
-            if (mainPlaylist.variants.length === 0) return null
-            try {
-                const playlist = await data.getMediaPlaylist(
-                    mainPlaylist.variants[0].uri
-                )
-                let total = 0
-                for (const seg of playlist.segments) total += seg.duration
-                cachedDuration = total > 0 ? total : null
-            } catch {
-                return null
+            if (mainPlaylist.variants.length === 0) {
+                throw new Error('Unable to determine HLS duration: no variants')
             }
+            const playlist = await data.getMediaPlaylist(
+                mainPlaylist.variants[0].uri
+            )
+            // Live playlists (no EXT-X-ENDLIST) have unbounded duration.
+            if (!playlist.ended) return Infinity
+            if (playlist.segments.length === 0) {
+                throw new Error(
+                    'Unable to determine HLS duration: no segments in media playlist'
+                )
+            }
+            let total = 0
+            for (const seg of playlist.segments) total += seg.duration
+            cachedDuration = total
             return cachedDuration
         },
     }

--- a/packages/vinyl/src/track/mse/MseTrack.ts
+++ b/packages/vinyl/src/track/mse/MseTrack.ts
@@ -100,6 +100,7 @@ export class MseTrack extends TrackBase {
                     .then((contentTypes) => {
                         if (this.disposer.disposed) return
                         if (equalDeep(this.contentTypes, contentTypes)) return // no-op
+                        logDebug(this, 'content types:', contentTypes)
                         this.clearStreams()
                         for (const contentType of contentTypes) {
                             this.createStream(contentType)

--- a/packages/vinyl/test/integ/track/hls/hls.test.ts
+++ b/packages/vinyl/test/integ/track/hls/hls.test.ts
@@ -29,7 +29,12 @@ describe('hls integ', () => {
             uri: vinylTestAssets.hls.live_static_aac_opus_flac_60s,
         },
     ]
-    const suite = createVinylSuite()
+    const suite = createVinylSuite(
+        {},
+        {
+            timeout: 180,
+        }
+    )
 
     beforeEach(() => {
         if (!supportsMse()) pending('MSE not supported')

--- a/packages/vinyl/test/unit/streaming/MediaTimeline.test.ts
+++ b/packages/vinyl/test/unit/streaming/MediaTimeline.test.ts
@@ -28,6 +28,7 @@ describe('getMediaPeriodAtTime', () => {
     const timeline: MediaTimeline = {
         periods: [period1, period2, period3],
         minBufferTime: 2,
+        getDuration: () => Promise.resolve(30),
     }
 
     it('returns the first period for time 0', () => {
@@ -55,7 +56,11 @@ describe('getMediaPeriodAtTime', () => {
     })
 
     it('returns null for empty timeline', () => {
-        const empty: MediaTimeline = { periods: [], minBufferTime: 0 }
+        const empty: MediaTimeline = {
+            periods: [],
+            minBufferTime: 0,
+            getDuration: () => Promise.resolve(0),
+        }
         expect(getMediaPeriodAtTime(empty, 5)).toBeNull()
     })
 })

--- a/packages/vinyl/test/unit/streaming/MseTrack.test.ts
+++ b/packages/vinyl/test/unit/streaming/MseTrack.test.ts
@@ -629,6 +629,7 @@ describe('MseTrack', () => {
                     },
                 ],
                 minBufferTime: 2,
+                getDuration: () => Promise.resolve(Infinity),
             })
             track = createTrack()
             await flushPromises()
@@ -651,6 +652,7 @@ describe('MseTrack', () => {
                     },
                 ],
                 minBufferTime: 2,
+                getDuration: () => Promise.resolve(Infinity),
             })
             track = createTrack()
             const spy = createEventSpy(track, 'qualitiesChange')
@@ -686,6 +688,7 @@ describe('MseTrack', () => {
                     },
                 ],
                 minBufferTime: 2,
+                getDuration: () => Promise.resolve(Infinity),
             }
             setTimeline(timeline)
             track = createTrack()
@@ -721,6 +724,7 @@ describe('MseTrack', () => {
                     },
                 ],
                 minBufferTime: 2,
+                getDuration: () => Promise.resolve(Infinity),
             })
             track = createTrack()
             await flushPromises()

--- a/packages/vinyl/test/unit/streaming/SegmentControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/streaming/SegmentControllerImpl.test.ts
@@ -132,6 +132,7 @@ describe('SegmentControllerImpl', () => {
                 },
             ],
             minBufferTime: 10,
+            getDuration: () => Promise.resolve(100),
         }
 
         const mockQualitySelector: QualitySelector = {
@@ -319,6 +320,7 @@ describe('SegmentControllerImpl', () => {
                         },
                     ],
                     minBufferTime: 10,
+                    getDuration: () => Promise.resolve(110),
                 }
                 timelineData.value = Promise.resolve(extendedTimeline)
 
@@ -447,6 +449,7 @@ describe('SegmentControllerImpl', () => {
                     },
                 ],
                 minBufferTime: 10,
+                getDuration: () => Promise.resolve(100),
             })
             // segmentController is for 'audio', but only 'video' qualities exist
             expect(await segmentController.getSegment(5)).toBeNull()
@@ -753,43 +756,6 @@ describe('SegmentControllerImpl', () => {
             })
             expect(segmentController.trackPrefetchPriority).toBe(3)
             expect(segmentController.startTime).toBe(4)
-        })
-    })
-
-    describe('duration', () => {
-        it('delegates to the media timeline', async () => {
-            expect(await segmentController.getDuration()).toBe(100)
-        })
-
-        it('returns null for empty timeline', async () => {
-            timelineData.value = Promise.resolve({
-                periods: [],
-                minBufferTime: 0,
-            })
-            expect(await segmentController.getDuration()).toBeNull()
-        })
-
-        it('returns null when last period has Infinity endTime', async () => {
-            timelineData.value = Promise.resolve({
-                periods: [
-                    {
-                        startTime: 0,
-                        endTime: Infinity,
-                        qualities: [],
-                    },
-                ],
-                minBufferTime: 0,
-            })
-            expect(await segmentController.getDuration()).toBeNull()
-        })
-
-        it('uses getDuration from timeline when provided', async () => {
-            timelineData.value = Promise.resolve({
-                periods: [],
-                minBufferTime: 0,
-                getDuration: () => Promise.resolve(42),
-            })
-            expect(await segmentController.getDuration()).toBe(42)
         })
     })
 

--- a/packages/vinyl/test/unit/streaming/buffering/BufferingController.test.ts
+++ b/packages/vinyl/test/unit/streaming/buffering/BufferingController.test.ts
@@ -19,9 +19,7 @@ import {
     type ContentType,
     createEmptyMediaQualityMetadata,
     DEFAULT_MAX_APPEND_SIZE,
-    DURATION_PADDING,
     getSourceBufferQuota,
-    LIVE_DURATION,
     type MediaQualityMetadata,
     MIN_APPEND_SIZE,
     POLL_BUFFER_THROTTLE,
@@ -137,7 +135,6 @@ describe('BufferingControllerImpl', () => {
 
     beforeEach(() => {
         mediaSourceController = new MockMediaSourceController()
-        mediaSourceController.duration = Number.NaN
         playbackController = new MockPlaybackController()
         segmentController = new MockSegmentController()
         segmentController.getSegment.and.callFake((time) => {
@@ -675,58 +672,6 @@ describe('BufferingControllerImpl', () => {
             bufferingController.activate()
             await nextPollImmediate()
             expect(bufferingController.getBufferedTime()).toBe(10)
-        })
-    })
-
-    describe('duration', () => {
-        beforeEach(() => {
-            bufferingController = createBufferingController()
-            bufferingController.activate()
-        })
-
-        describe('when the media source is open and the segment controller is not updating', () => {
-            it('is set to the segment controller provided value', async () => {
-                segmentController.getDuration.and.resolveTo(33)
-                await open()
-                expect(mediaSourceController.duration).toEqual(
-                    33 + DURATION_PADDING
-                )
-            })
-
-            describe('when segment controller duration resolves to null', () => {
-                it('sets mediaSource duration to LIVE_DURATION', async () => {
-                    segmentController.getDuration.and.resolveTo(null)
-                    await open()
-                    expect(mediaSourceController.duration).toEqual(
-                        LIVE_DURATION
-                    )
-                })
-            })
-        })
-
-        describe('when segment controller emits a change event', () => {
-            it('refreshes duration', async () => {
-                segmentController.getDuration.and.resolveTo(42)
-                await open()
-                expect(mediaSourceController.duration).toEqual(
-                    42 + DURATION_PADDING
-                )
-                segmentController.getDuration.and.resolveTo(54)
-                segmentController.dispatch('change', {})
-                await nextPollImmediate()
-                expect(mediaSourceController.duration).toEqual(
-                    54 + DURATION_PADDING
-                )
-            })
-
-            describe('and mediaSource is not open', () => {
-                it('does nothing', () => {
-                    // Closed
-                    segmentController.getDuration.and.resolveTo(52)
-                    segmentController.dispatch('change', {})
-                    expect(mediaSourceController.duration).toBeNaN()
-                })
-            })
         })
     })
 

--- a/packages/vinyl/test/unit/streaming/buffering/MediaSourceController.test.ts
+++ b/packages/vinyl/test/unit/streaming/buffering/MediaSourceController.test.ts
@@ -5,13 +5,18 @@
 
 import {
     type ContentType,
+    DURATION_PADDING,
+    LIVE_DURATION,
+    type MediaTimeline,
     MediaSourceControllerImpl,
     type MediaSourceControllerImplDeps,
     MediaSourceError,
 } from '@amazon/vinyl'
-import { Deferred, type ReadonlySet } from '@amazon/vinyl-util'
+import { AbortError, Deferred, type ReadonlySet } from '@amazon/vinyl-util'
 import {
     flushPromises,
+    implementEventFakes,
+    mockEvent,
     MockMediaSource,
     MockSourceBuffer,
 } from '@amazon/vinyl-util/browserTestUtil'
@@ -21,15 +26,36 @@ import objectContaining = jasmine.objectContaining
 import Spy = jasmine.Spy
 import { createEventSpy } from '@amazon/vinyl-util/testUtil'
 
+const VOD_DURATION = 60
+function createVodTimeline(duration: number = VOD_DURATION): MediaTimeline {
+    return {
+        periods: [],
+        minBufferTime: 0,
+        getDuration: () => Promise.resolve(duration),
+    }
+}
+const liveTimeline: MediaTimeline = {
+    periods: [],
+    minBufferTime: 0,
+    getDuration: () => Promise.resolve(Infinity),
+}
+
 describe('MediaSourceControllerImpl', () => {
     let mediaSourceFactory: Spy<() => MediaSource>
     let contentTypesValue: MutableValue<Promise<ReadonlySet<ContentType>>>
+    let mediaTimelineTransformed: MutableValue<Promise<MediaTimeline>>
     let mockMediaSource: MockMediaSource
     let deps: MediaSourceControllerImplDeps
     let controller: MediaSourceControllerImpl
 
+    function open(): void {
+        mockMediaSource.readyState = 'open'
+        mockMediaSource.dispatchEvent(mockEvent('sourceopen'))
+    }
+
     beforeEach(() => {
         mockMediaSource = new MockMediaSource()
+        implementEventFakes(mockMediaSource)
         mockMediaSource.addSourceBuffer.and.callFake(
             () => new MockSourceBuffer()
         )
@@ -39,10 +65,14 @@ describe('MediaSourceControllerImpl', () => {
         contentTypesValue = data<Promise<ReadonlySet<ContentType>>>(
             Promise.resolve(new Set(['audio']))
         )
+        mediaTimelineTransformed = data<Promise<MediaTimeline>>(
+            Promise.resolve(createVodTimeline())
+        )
 
         deps = {
             mediaSourceFactory,
             contentTypesValue,
+            mediaTimelineTransformed,
         }
 
         controller = new MediaSourceControllerImpl(deps)
@@ -66,14 +96,83 @@ describe('MediaSourceControllerImpl', () => {
     })
 
     describe('duration', () => {
-        it('gets duration from media source', () => {
-            mockMediaSource.duration = 123.45
-            expect(controller.duration).toBe(123.45)
+        it('sets media source duration after sourceopen', async () => {
+            open()
+            await flushPromises()
+            expect(mockMediaSource.duration).toBe(
+                VOD_DURATION + DURATION_PADDING
+            )
         })
 
-        it('sets duration on media source', () => {
-            controller.duration = 67.89
-            expect(mockMediaSource.duration).toBe(67.89)
+        it('uses LIVE_DURATION for live timelines', async () => {
+            mediaTimelineTransformed.value = Promise.resolve(liveTimeline)
+            open()
+            await flushPromises()
+            expect(mockMediaSource.duration).toBe(LIVE_DURATION)
+        })
+
+        it('does not set duration when media source is not open', async () => {
+            await flushPromises()
+            expect(mockMediaSource.duration).toBe(0)
+        })
+
+        it('refreshes duration when timeline changes', async () => {
+            open()
+            await flushPromises()
+            expect(mockMediaSource.duration).toBe(
+                VOD_DURATION + DURATION_PADDING
+            )
+            mediaTimelineTransformed.value = Promise.resolve(
+                createVodTimeline(120)
+            )
+            await flushPromises()
+            expect(mockMediaSource.duration).toBe(120 + DURATION_PADDING)
+        })
+
+        it('emits an error if getDuration rejects', async () => {
+            const errorSpy = createEventSpy(controller, 'error')
+            const error = new Error('expected')
+            mediaTimelineTransformed.value = Promise.resolve({
+                periods: [],
+                minBufferTime: 0,
+                getDuration: () => Promise.reject(error),
+            })
+            open()
+            await flushPromises()
+            expect(errorSpy).toHaveBeenCalledWith({
+                target: controller,
+                error,
+            })
+        })
+
+        it('does not emit silent (abort) errors', async () => {
+            const errorSpy = createEventSpy(controller, 'error')
+            mediaTimelineTransformed.value = Promise.resolve({
+                periods: [],
+                minBufferTime: 0,
+                getDuration: () => Promise.reject(new AbortError()),
+            })
+            open()
+            await flushPromises()
+            expect(errorSpy).not.toHaveBeenCalled()
+        })
+
+        it('discards a duration result if the source closed before it resolved', async () => {
+            const deferred = new Deferred<number>()
+            mediaTimelineTransformed.value = Promise.resolve({
+                periods: [],
+                minBufferTime: 0,
+                getDuration: () => deferred,
+            })
+            open()
+            await flushPromises()
+            // Close before the duration resolves; the late result should be ignored.
+            mockMediaSource.readyState = 'closed'
+            mockMediaSource.dispatchEvent(mockEvent('sourceclose'))
+            deferred.resolve(123)
+            await flushPromises()
+            expect(mockMediaSource.duration).toBe(0)
+            expect(controller.readyToAppend).toBeFalse()
         })
     })
 
@@ -86,8 +185,6 @@ describe('MediaSourceControllerImpl', () => {
         })
 
         it('creates source buffer with correct mime type', () => {
-            const controller = new MediaSourceControllerImpl(deps)
-
             const ref = controller.createSourceBuffer('audio', 'audio/mp4')
             expect(mockMediaSource.addSourceBuffer).toHaveBeenCalledWith(
                 'audio/mp4'
@@ -96,13 +193,11 @@ describe('MediaSourceControllerImpl', () => {
         })
 
         it('sets source buffer mode to sequence', () => {
-            const controller = new MediaSourceControllerImpl(deps)
             controller.createSourceBuffer('audio', 'audio/mp4')
             expect(mockSourceBuffer.mode).toBe('sequence')
         })
 
         it('emits error events when contentTypesValue rejects', async () => {
-            const controller = new MediaSourceControllerImpl(deps)
             const errorSpy = createEventSpy(controller, 'error')
             const error = new Error('expected error')
             contentTypesValue.value = Promise.reject(error)
@@ -114,8 +209,12 @@ describe('MediaSourceControllerImpl', () => {
         })
 
         describe('readyToAppend', () => {
-            it('is true when all streams have been created', async () => {
-                const controller = new MediaSourceControllerImpl(deps)
+            it('is true only after duration is set and all source buffers are created', async () => {
+                // Each createSourceBuffer must return a distinct SourceBuffer because
+                // the controller dedupes buffers by identity.
+                mockMediaSource.addSourceBuffer.and.callFake(
+                    () => new MockSourceBuffer()
+                )
                 const readyToAppendSpy = createEventSpy(
                     controller,
                     'readyToAppend'
@@ -123,7 +222,14 @@ describe('MediaSourceControllerImpl', () => {
                 expect(controller.readyToAppend).toBeFalse()
                 await flushPromises()
                 expect(readyToAppendSpy).not.toHaveBeenCalled()
+
+                // Source buffer alone is not enough — duration must be set.
                 controller.createSourceBuffer('audio', 'audio/mp4')
+                expect(controller.readyToAppend).toBeFalse()
+                expect(readyToAppendSpy).not.toHaveBeenCalled()
+
+                open()
+                await flushPromises()
                 expect(controller.readyToAppend).toBeTrue()
                 expect(readyToAppendSpy).toHaveBeenCalledTimes(1)
                 readyToAppendSpy.calls.reset()
@@ -143,8 +249,6 @@ describe('MediaSourceControllerImpl', () => {
         })
 
         it('throws MediaSourceError when addSourceBuffer fails', () => {
-            const controller = new MediaSourceControllerImpl(deps)
-
             const error = new Error('test error')
             mockMediaSource.addSourceBuffer.and.throwError(error)
 
@@ -155,7 +259,6 @@ describe('MediaSourceControllerImpl', () => {
 
         describe('SourceBufferRef disposal', () => {
             it('removes source buffer from media source', () => {
-                const controller = new MediaSourceControllerImpl(deps)
                 mockMediaSource.readyState = 'open'
 
                 const ref = controller.createSourceBuffer('audio', 'audio/mp4')
@@ -166,7 +269,6 @@ describe('MediaSourceControllerImpl', () => {
             })
 
             it('does not remove source buffer when media source is closed', () => {
-                const controller = new MediaSourceControllerImpl(deps)
                 mockMediaSource.readyState = 'open'
 
                 const ref = controller.createSourceBuffer('audio', 'audio/mp4')

--- a/packages/vinyl/test/unit/streaming/createDefaultMediaTimelineTransformer.test.ts
+++ b/packages/vinyl/test/unit/streaming/createDefaultMediaTimelineTransformer.test.ts
@@ -68,6 +68,7 @@ describe('createDefaultMediaTimelineTransformer', () => {
                 },
             ],
             minBufferTime: 2,
+            getDuration: () => Promise.resolve(Infinity),
         }
         const result = await createDefaultMediaTimelineTransformer(
             createDeps(timeline)
@@ -100,6 +101,7 @@ describe('createDefaultMediaTimelineTransformer', () => {
                 },
             ],
             minBufferTime: 2,
+            getDuration: () => Promise.resolve(Infinity),
         }
         const result = await createDefaultMediaTimelineTransformer(
             createDeps(timeline)
@@ -140,6 +142,7 @@ describe('createDefaultMediaTimelineTransformer', () => {
                 },
             ],
             minBufferTime: 2,
+            getDuration: () => Promise.resolve(Infinity),
         }
         const result = await createDefaultMediaTimelineTransformer(
             createDeps(timeline)
@@ -173,6 +176,7 @@ describe('createDefaultMediaTimelineTransformer', () => {
                 },
             ],
             minBufferTime: 2,
+            getDuration: () => Promise.resolve(Infinity),
         }
         const result = await createDefaultMediaTimelineTransformer(
             createDeps(timeline, 'en')
@@ -204,6 +208,7 @@ describe('createDefaultMediaTimelineTransformer', () => {
                 },
             ],
             minBufferTime: 2,
+            getDuration: () => Promise.resolve(Infinity),
         }
         const options = data({
             preferredAudioLanguage: 'en',
@@ -240,6 +245,7 @@ describe('createDefaultMediaTimelineTransformer', () => {
                 },
             ],
             minBufferTime: 5,
+            getDuration: () => Promise.resolve(Infinity),
         }
         const result = await createDefaultMediaTimelineTransformer(
             createDeps(timeline)

--- a/packages/vinyl/test/unit/streaming/mediaTimelineFilter.test.ts
+++ b/packages/vinyl/test/unit/streaming/mediaTimelineFilter.test.ts
@@ -39,6 +39,7 @@ describe('filterTimelineQualities', () => {
             },
         ],
         minBufferTime: 2,
+        getDuration: () => Promise.resolve(Infinity),
     }
 
     it('filters qualities by predicate', () => {
@@ -94,6 +95,7 @@ describe('filterTimelineQualitiesAsync', () => {
             },
         ],
         minBufferTime: 2,
+        getDuration: () => Promise.resolve(Infinity),
     }
 
     it('filters qualities by async predicate', async () => {

--- a/packages/vinyl/test/unit/streaming/mediaTimelineLanguageFilter.test.ts
+++ b/packages/vinyl/test/unit/streaming/mediaTimelineLanguageFilter.test.ts
@@ -61,6 +61,7 @@ describe('createLanguageFilter', () => {
                 },
             ],
             minBufferTime: 2,
+            getDuration: () => Promise.resolve(Infinity),
         }
         const result = applyLanguageFilter(timeline, 'en', 'audio')
         expect(result.periods[0].qualities.length).toBe(2) // en audio + video
@@ -80,6 +81,7 @@ describe('createLanguageFilter', () => {
                 },
             ],
             minBufferTime: 2,
+            getDuration: () => Promise.resolve(Infinity),
         }
         const result = applyLanguageFilter(timeline, 'en', 'audio')
         expect(result.periods[0].qualities.length).toBe(2) // en + null
@@ -95,6 +97,7 @@ describe('createLanguageFilter', () => {
                 },
             ],
             minBufferTime: 5,
+            getDuration: () => Promise.resolve(Infinity),
         }
         const result = applyLanguageFilter(timeline, 'en', 'audio')
         expect(result.minBufferTime).toBe(5)
@@ -114,6 +117,7 @@ describe('createLanguageFilter', () => {
                 },
             ],
             minBufferTime: 2,
+            getDuration: () => Promise.resolve(Infinity),
         }
         const result = applyLanguageFilter(timeline, 'en', 'audio')
         expect(
@@ -133,6 +137,7 @@ describe('createLanguageFilter', () => {
                 },
             ],
             minBufferTime: 2,
+            getDuration: () => Promise.resolve(Infinity),
         }
         // 'xx' doesn't match 'ja', so all kept
         const result = applyLanguageFilter(timeline, 'xx', 'audio')
@@ -160,6 +165,7 @@ describe('createLanguageFilter', () => {
                 },
             ],
             minBufferTime: 2,
+            getDuration: () => Promise.resolve(Infinity),
         }
         // 'en' matches period 1 but not period 2
         // Period 1: filtered to 'en' only
@@ -191,6 +197,7 @@ describe('createLanguageFilter', () => {
                 },
             ],
             minBufferTime: 2,
+            getDuration: () => Promise.resolve(Infinity),
         }
         const result = applyLanguageFilter(timeline, 'en', 'audio')
         // Period 1: filtered to 'en'

--- a/packages/vinyl/test/unit/track/dash/buildDashMediaTimeline.test.ts
+++ b/packages/vinyl/test/unit/track/dash/buildDashMediaTimeline.test.ts
@@ -82,7 +82,7 @@ describe('buildDashMediaTimeline', () => {
             baseUrl: 'https://example.com/',
         }
         const timeline = buildDashMediaTimeline(deps, data)
-        const duration = await timeline.getDuration!()
+        const duration = await timeline.getDuration()
         expect(duration).toEqual(jasmine.any(Number))
     })
 })

--- a/packages/vinyl/test/unit/track/dash/createDashContentStreamFactories.test.ts
+++ b/packages/vinyl/test/unit/track/dash/createDashContentStreamFactories.test.ts
@@ -24,7 +24,11 @@ describe('createDashContentStreamFactories', () => {
     let playbackController: MockPlaybackController
     let qualitySelector: MockQualitySelector
 
-    const emptyTimeline: MediaTimeline = { periods: [], minBufferTime: 0 }
+    const emptyTimeline: MediaTimeline = {
+        periods: [],
+        minBufferTime: 0,
+        getDuration: () => Promise.resolve(Infinity),
+    }
 
     beforeEach(() => {
         mediaSourceController = new MockMediaSourceController()

--- a/packages/vinyl/test/unit/track/dash/createSegmentControllerFactory.test.ts
+++ b/packages/vinyl/test/unit/track/dash/createSegmentControllerFactory.test.ts
@@ -15,7 +15,11 @@ import objectContaining = jasmine.objectContaining
 describe('createSegmentControllerFactory', () => {
     it('creates SegmentControllerImpl with merged dependencies', () => {
         const playbackController = new MockPlaybackController()
-        const emptyTimeline: MediaTimeline = { periods: [], minBufferTime: 0 }
+        const emptyTimeline: MediaTimeline = {
+            periods: [],
+            minBufferTime: 0,
+            getDuration: () => Promise.resolve(Infinity),
+        }
 
         const factory = createSegmentControllerFactory(
             { playbackController },

--- a/packages/vinyl/test/unit/track/dash/util/mpd.test.ts
+++ b/packages/vinyl/test/unit/track/dash/util/mpd.test.ts
@@ -359,5 +359,41 @@ describe('mpd utils', () => {
                 expect(calculateDuration(manifest)).toBe(50)
             })
         })
+
+        describe('when MPD type is dynamic', () => {
+            it('returns Infinity for live presentations', () => {
+                // language=XML
+                const manifest = parseDashManifest(`<?xml version="1.0" ?>
+<MPD type="dynamic" minBufferTime="PT0.0S" profiles="urn:mpeg:dash:profile:isoff-live:2011" xmlns="urn:mpeg:dash:schema:mpd:2011">
+  <Period/>
+</MPD>`)
+                expect(calculateDuration(manifest)).toBe(Infinity)
+            })
+        })
+
+        describe('when there are no periods', () => {
+            it('throws', () => {
+                const manifest = clone(mockDashManifest)
+                delete (manifest.MPD as { mediaPresentationDuration?: number })
+                    .mediaPresentationDuration
+                ;(manifest.MPD as { Period: unknown }).Period = []
+                expect(() => calculateDuration(manifest)).toThrowError(
+                    /no periods/i
+                )
+            })
+        })
+
+        describe('when the last period has no determinable end', () => {
+            it('throws', () => {
+                // language=XML
+                const manifest = parseDashManifest(`<?xml version="1.0" ?>
+<MPD minBufferTime="PT0.0S" profiles="urn:mpeg:dash:profile:isoff-live:2011" xmlns="urn:mpeg:dash:schema:mpd:2011">
+  <Period/>
+</MPD>`)
+                expect(() => calculateDuration(manifest)).toThrowError(
+                    /Unable to determine/
+                )
+            })
+        })
     })
 })

--- a/packages/vinyl/test/unit/track/hls/buildHlsMediaTimeline.test.ts
+++ b/packages/vinyl/test/unit/track/hls/buildHlsMediaTimeline.test.ts
@@ -24,9 +24,13 @@ describe('buildHlsMediaTimeline', () => {
         }
     }
 
-    function createMediaPlaylist(durations: number[]): MediaPlaylist {
+    function createMediaPlaylist(
+        durations: number[],
+        ended = true
+    ): MediaPlaylist {
         return {
-            targetDuration: Math.max(...durations),
+            targetDuration: durations.length ? Math.max(...durations) : 0,
+            ended,
             segments: durations.map((d, i) => ({
                 duration: d,
                 uri: `seg${i}.m4s`,
@@ -77,7 +81,16 @@ describe('buildHlsMediaTimeline', () => {
         const data = createManifestData([variant], playlist)
 
         const timeline = buildHlsMediaTimeline(deps, data)
-        expect(await timeline.getDuration!()).toBe(12)
+        expect(await timeline.getDuration()).toBe(12)
+    })
+
+    it('returns Infinity for live playlists (no EXT-X-ENDLIST)', async () => {
+        const variant = createVariant('v1.m3u8', 128000)
+        const playlist = createMediaPlaylist([4, 4], false)
+        const data = createManifestData([variant], playlist)
+
+        const timeline = buildHlsMediaTimeline(deps, data)
+        expect(await timeline.getDuration()).toBe(Infinity)
     })
 
     it('creates one quality per variant', () => {
@@ -256,7 +269,7 @@ describe('buildHlsMediaTimeline', () => {
         expect(segment!.quality.codecs).toBeNull()
     })
 
-    it('getDuration returns null when getMediaPlaylist fails', async () => {
+    it('getDuration rejects when getMediaPlaylist fails', async () => {
         const variant = createVariant('v1.m3u8', 128000)
         const manifestData: HlsManifestData = {
             mainPlaylist: {
@@ -267,7 +280,7 @@ describe('buildHlsMediaTimeline', () => {
             getMediaPlaylist: () => Promise.reject(new Error('disposed')),
         }
         const timeline = buildHlsMediaTimeline(deps, manifestData)
-        expect(await timeline.getDuration!()).toBeNull()
+        await expectAsync(timeline.getDuration()).toBeRejected()
     })
 
     it('getDuration caches the result', async () => {
@@ -286,17 +299,19 @@ describe('buildHlsMediaTimeline', () => {
             },
         }
         const timeline = buildHlsMediaTimeline(deps, manifestData)
-        expect(await timeline.getDuration!()).toBe(10)
-        expect(await timeline.getDuration!()).toBe(10)
+        expect(await timeline.getDuration()).toBe(10)
+        expect(await timeline.getDuration()).toBe(10)
         expect(calls).toBe(1)
     })
 
-    it('getDuration returns null for empty segments', async () => {
+    it('getDuration throws for empty segments in a complete playlist', async () => {
         const variant = createVariant('v1.m3u8', 128000)
         const playlist = createMediaPlaylist([])
         const manifestData = createManifestData([variant], playlist)
         const timeline = buildHlsMediaTimeline(deps, manifestData)
-        expect(await timeline.getDuration!()).toBeNull()
+        await expectAsync(timeline.getDuration()).toBeRejectedWithError(
+            /no segments/i
+        )
     })
 
     it('passes byteRange from map to createSegmentDataProvider as mediaRange', async () => {
@@ -350,9 +365,11 @@ describe('buildHlsMediaTimeline', () => {
         fetchSpy.and.callThrough()
     })
 
-    it('getDuration returns null when no variants', async () => {
+    it('getDuration throws when no variants', async () => {
         const manifestData = createManifestData([], createMediaPlaylist([]))
         const timeline = buildHlsMediaTimeline(deps, manifestData)
-        expect(await timeline.getDuration!()).toBeNull()
+        await expectAsync(timeline.getDuration()).toBeRejectedWithError(
+            /no variants/i
+        )
     })
 })

--- a/packages/vinyl/test/unit/track/hls/createHlsContentStreamFactories.test.ts
+++ b/packages/vinyl/test/unit/track/hls/createHlsContentStreamFactories.test.ts
@@ -22,7 +22,11 @@ import any = jasmine.any
 describe('createHlsContentStreamFactories', () => {
     let deps: HlsContentStreamTrackDeps
 
-    const emptyTimeline: MediaTimeline = { periods: [], minBufferTime: 0 }
+    const emptyTimeline: MediaTimeline = {
+        periods: [],
+        minBufferTime: 0,
+        getDuration: () => Promise.resolve(Infinity),
+    }
 
     beforeEach(() => {
         deps = {

--- a/packages/vinyl/test/vinylTestUtil/mock/streaming/MockSegmentController.ts
+++ b/packages/vinyl/test/vinylTestUtil/mock/streaming/MockSegmentController.ts
@@ -20,8 +20,6 @@ export class MockSegmentController
 {
     error: Error | null = null
 
-    getDuration = spyFactory('getDuration')
-
     configure = spyFactory('configure')
 
     fetchedRanges = emptyRanges

--- a/packages/vinyl/test/vinylTestUtil/mock/streaming/buffering/MockMediaSourceController.ts
+++ b/packages/vinyl/test/vinylTestUtil/mock/streaming/buffering/MockMediaSourceController.ts
@@ -16,8 +16,6 @@ export class MockMediaSourceController
     extends MockEventHost<MediaSourceControllerEventMap>
     implements MediaSourceController
 {
-    duration = 0
-
     readyState: ReadyState = 'closed'
     createSourceBuffer = spyFactory('createSourceBuffer')
     endOfStream = spyFactory('endOfStream')

--- a/packages/vinyl/test/vinylTestUtil/mock/track/dash/createMockDashDependencies.ts
+++ b/packages/vinyl/test/vinylTestUtil/mock/track/dash/createMockDashDependencies.ts
@@ -21,7 +21,11 @@ import { data } from '@amazon/vinyl-observable'
 
 import createSpy = jasmine.createSpy
 
-const emptyTimeline: MediaTimeline = { periods: [], minBufferTime: 0 }
+const emptyTimeline: MediaTimeline = {
+    periods: [],
+    minBufferTime: 0,
+    getDuration: () => Promise.resolve(Infinity),
+}
 
 const spyFactory = createSpyFactory<DashTrackDeps>()
 export function createMockDashDependencies() {

--- a/packages/vinyl/test/vinylTestUtil/mock/track/hls/createMockHlsDependencies.ts
+++ b/packages/vinyl/test/vinylTestUtil/mock/track/hls/createMockHlsDependencies.ts
@@ -21,7 +21,11 @@ import { data } from '@amazon/vinyl-observable'
 
 import createSpy = jasmine.createSpy
 
-const emptyTimeline: MediaTimeline = { periods: [], minBufferTime: 0 }
+const emptyTimeline: MediaTimeline = {
+    periods: [],
+    minBufferTime: 0,
+    getDuration: () => Promise.resolve(Infinity),
+}
 
 const spyFactory = createSpyFactory<HlsTrackDeps>()
 export function createMockHlsDependencies() {

--- a/packages/vinyl/test/vinylTestUtil/util/playback/expectTrackPlays.ts
+++ b/packages/vinyl/test/vinylTestUtil/util/playback/expectTrackPlays.ts
@@ -72,7 +72,7 @@ export async function expectPlaylistPlays<T extends TrackLoadOptions>(
 ): Promise<void> {
     const { dispose, add } = createDisposer()
     // Add a significant buffer to the timeout; progressive tracks can take a long time to load after a seek.
-    const trackTimeout = PLAYBACK_DURATION + 30 // Timeout to give each track
+    const trackTimeout = PLAYBACK_DURATION + 60 // Timeout to give each track
     const queueEnded = add(createEventSpy(player, 'queueEnded'))
     const queueChange = add(createEventSpy(player, 'queueChange'))
     const trackChange = add(createEventSpy(player, 'currentTrackChange'))


### PR DESCRIPTION
own duration in MediaSourceController

Move media source duration setting out of BufferingController, where it
ran per-stream, into MediaSourceController, where the source is owned.
Make MediaTimeline.getDuration required (returns Infinity for live,
throws if duration cannot be derived) and remove getDuration from
SegmentController. readyToAppend now waits until duration is set so
appends never race the duration update.