### PR TITLE
omit robustness when caller hasn't set one

### DIFF
--- a/packages/vinyl/src/drm/DrmControllerImpl.ts
+++ b/packages/vinyl/src/drm/DrmControllerImpl.ts
@@ -30,7 +30,6 @@ import { instanceOf, object, type ObjectSchema } from '@amazon/vinyl-validation'
 import {
     type DrmMediaKeySystemOptions,
     type DrmOptions,
-    DrmRobustness,
     type InitDataTransformer,
 } from './DrmOptions'
 import type {
@@ -410,9 +409,10 @@ export class DrmControllerImpl
                 drmInfo.contentType
             )
             const capability: MediaKeySystemMediaCapability = {
-                robustness:
-                    mediaOptions?.robustness ?? DrmRobustness.SW_SECURE_CRYPTO,
                 encryptionScheme: drmInfo.encryptionScheme,
+            }
+            if (mediaOptions?.robustness) {
+                capability.robustness = mediaOptions.robustness
             }
             if (drmInfo.mimeType) {
                 capability.contentType = drmInfo.mimeType

--- a/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
@@ -594,7 +594,6 @@ describe('DrmControllerImpl', () => {
                             {
                                 contentType: 'audio/mp4',
                                 encryptionScheme: 'cenc',
-                                robustness: DrmRobustness.SW_SECURE_CRYPTO,
                             },
                         ],
                     },


### PR DESCRIPTION
Drop the implicit SW_SECURE_CRYPTO default. When mediaOptions.robustness
is unset, leave robustness off the capability so the browser is free to
match any level. Callers that need a minimum should configure it
expli