### PR TITLE
feat(vinyl): expose resetPending state on VinylPlayer

### DIFF
--- a/packages/vinyl/src/track/AutoResetController.ts
+++ b/packages/vinyl/src/track/AutoResetController.ts
@@ -8,49 +8,74 @@ import {
     type Clearable,
     createDisposer,
     type Disposable,
-    ErrorOrigin,
     EventHostImpl,
     getNetworkState,
     logDebug,
     onAny,
     type ReadonlyEventHost,
-    ReportableError,
+    RequestError,
     type Unsubscribe,
 } from '@amazon/vinyl-util'
 import type { PlaybackController } from '../playback/PlaybackController'
+import type { ChangeEvent } from '../event/ChangeEvent'
 
 export interface AutoResetControllerEventMap {
     /**
      * Notifies that playback errors should be reset and retried.
      */
     readonly reset: AnyRecord
+
+    /**
+     * Dispatched when {@link AutoResetController.resetPending} changes.
+     */
+    readonly resetPendingChange: ChangeEvent<boolean>
 }
 
 /**
- * Notifies when playback should be reset and retried.
+ * Notifies when playback should be reset and retried after a transient,
+ * potentially-recoverable error.
  *
- * The controller monitors for retry opportunities after an error is set:
- * - Immediately on network 'online' events
- * - After a timeout interval if online
+ * Once an eligible error is set, the controller watches for opportunities
+ * to emit a `reset` event:
+ * - Immediately when the network transitions back to online
+ * - After a timeout interval, if online and retries are not exhausted
  * - Immediately on user playback actions (play, pause, seeking, playing)
  *
- * Each error triggers a single timeout. If another error occurs after a reset,
- * setError() should be called again to schedule the next retry attempt.
+ * Each error triggers a single retry timeout. If another error occurs
+ * after a reset, {@link AutoResetController.setError} should be called again
+ * to schedule the next retry attempt.
  */
 export interface AutoResetController
     extends ReadonlyEventHost<AutoResetControllerEventMap>, Clearable {
     /**
-     * Sets the current playback error and begins monitoring for retry opportunities.
+     * Sets the current playback error and, if eligible, begins watching for
+     * retry opportunities.
      *
-     * Only SERVICE_INTERNAL ReportableErrors are monitored. Subsequent calls while
-     * an error is already set are ignored until the error is cleared via reset or clear().
+     * An error is eligible when it is a {@link RequestError} that did not
+     * receive an HTTP response (i.e. `response == null`), indicating a
+     * transient network failure such as connection loss or DNS failure.
+     * All other errors — including HTTP failures with a response (4xx/5xx),
+     * and non-RequestError errors — are ignored, since those are unlikely
+     * to recover on their own.
      *
-     * After a reset, if another error occurs, this method should be called again
-     * to schedule the next retry attempt.
+     * Subsequent calls while an error is already set are ignored until the
+     * error is cleared via a reset emission or {@link Clearable.clear}.
+     *
+     * After a reset, if another eligible error occurs, this method should
+     * be called again to schedule the next retry attempt.
      *
      * @param error The error to monitor for retry opportunities
      */
     setError(error: Error): void
+
+    /**
+     * True while an eligible error is being watched and a `reset` event
+     * may still be emitted. Becomes false once the error is cleared, a
+     * reset is emitted, or all retries are exhausted.
+     *
+     * Listen to `resetPendingChange` events for changes.
+     */
+    readonly resetPending: boolean
 }
 
 export interface AutoResetControllerImplDeps {
@@ -132,42 +157,52 @@ export class AutoResetControllerImpl
 
     setError(error: Error): void {
         if (!this.options.enabled || this._error) return
-        if (
-            error instanceof ReportableError &&
-            error.origin === ErrorOrigin.SERVICE_INTERNAL
-        ) {
+        if (error instanceof RequestError && error.response == null) {
             this._error = error
-            this.setWatching(true)
+            this.setResetPending(true)
         }
     }
 
-    private setWatching(value: boolean): void {
-        logDebug(this, 'setWatching', value)
+    get resetPending(): boolean {
+        return this.watchSub != null
+    }
+
+    private setResetPending(value: boolean): void {
+        if (this.resetPending === value) {
+            logDebug(this, 'setResetPending', value, 'no-op')
+            return
+        }
+        logDebug(this, 'setResetPending', value)
         this.watchSub?.()
         this.watchSub = null
-        if (!value) return
-        const networkState = getNetworkState()
-        const { add, dispose: watchSub } = createDisposer()
-        this.watchSub = watchSub
-        add(
-            networkState.on('online', () => {
-                logDebug(this, 'online, emitting reset')
-                this.reset()
-            })
-        )
-
-        const intervalId = setTimeout(() => {
-            if (this.currentRetry++ < this.options.maxRetries) {
-                if (networkState.onLine) {
-                    logDebug(this, 'interval, emitting reset')
+        if (value) {
+            const networkState = getNetworkState()
+            const { add, dispose: watchSub } = createDisposer()
+            this.watchSub = watchSub
+            add(
+                networkState.on('online', () => {
+                    logDebug(this, 'online, emitting reset')
                     this.reset()
+                })
+            )
+
+            const intervalId = setTimeout(() => {
+                if (this.currentRetry++ < this.options.maxRetries) {
+                    if (networkState.onLine) {
+                        logDebug(this, 'interval, emitting reset')
+                        this.reset()
+                    }
+                } else {
+                    logDebug(this, 'max retries exhausted, pausing playback')
+                    this.setResetPending(false)
                 }
-            } else {
-                logDebug(this, 'max retries exhausted, pausing playback')
-                this.setWatching(false)
-            }
-        }, this.options.retryInterval * 1000)
-        add(() => clearTimeout(intervalId))
+            }, this.options.retryInterval * 1000)
+            add(() => clearTimeout(intervalId))
+        }
+        this.dispatch('resetPendingChange', {
+            previous: !value,
+            current: value,
+        })
     }
 
     private reset(): void {
@@ -179,7 +214,7 @@ export class AutoResetControllerImpl
     clear() {
         if (!this._error) return
         this._error = null
-        this.setWatching(false)
+        this.setResetPending(false)
     }
 
     get disposed(): boolean {

--- a/packages/vinyl/src/vinyl/VinylPlayer.ts
+++ b/packages/vinyl/src/vinyl/VinylPlayer.ts
@@ -67,6 +67,8 @@ import type {
     MutableValue,
 } from '@amazon/vinyl-observable'
 import type { VinylOptions } from './VinylOptions'
+import type { AutoResetController } from '../track/AutoResetController'
+import type { ChangeEvent } from '../event/ChangeEvent'
 
 /**
  * Events the Vinyl Player emits.
@@ -77,7 +79,21 @@ export interface VinylPlayerEventMap<
     extends
         PlaybackControllerEventMap,
         TrackControllerEventMap<TrackLoadOptionsType>,
-        StreamingEventMap {}
+        StreamingEventMap {
+    /**
+     * Dispatched when {@link VinylPlayer.resetPending} changes.
+     *
+     * `current` is true when the player has hit a transient, potentially
+     * recoverable error (e.g. a network outage) and an automatic reset
+     * attempt is scheduled. `current` is false once the pending reset is
+     * emitted, the error is cleared, or all retries are exhausted.
+     *
+     * If `resetPending` becomes false while {@link VinylPlayer.error} is
+     * still non-null, all automatic reset attempts have been exhausted
+     * and playback will not recover without user action.
+     */
+    readonly resetPendingChange: ChangeEvent<boolean>
+}
 
 /**
  * A Vinyl Media Player.
@@ -112,6 +128,10 @@ export class VinylPlayer<
 
     private get trackController(): TrackController<TrackLoadOptionsType> {
         return this.deps.trackController
+    }
+
+    private get autoResetController(): AutoResetController {
+        return this.deps.autoResetController
     }
 
     /**
@@ -237,11 +257,15 @@ export class VinylPlayer<
         // On an error, notify the auto reset controller which will
         // monitor network changes and periodically request a reset.
         const { add } = this.disposer
-        const { autoResetController } = this.deps
         this.on('error', (event) => {
-            autoResetController.setError(event.error)
+            this.autoResetController.setError(event.error)
         })
-        add(autoResetController.on('reset', () => this.reset()))
+        add(this.autoResetController.on('reset', () => this.reset()))
+        add(
+            this.autoResetController.on('resetPendingChange', (event) =>
+                this.dispatch('resetPendingChange', event)
+            )
+        )
     }
 
     private initializePreferredLanguageHandling() {
@@ -329,6 +353,18 @@ export class VinylPlayer<
      */
     get error(): Error | null {
         return this._error
+    }
+
+    /**
+     * True when an error has interrupted playback and an automatic reset
+     * is scheduled. This distinguishes transient, potentially recoverable
+     * errors (such as a brief network outage) from terminal errors that
+     * will not trigger a reset on their own.
+     *
+     * Listen to `resetPendingChange` events for changes.
+     */
+    get resetPending(): boolean {
+        return this.autoResetController.resetPending
     }
 
     get hasMetadata(): boolean {
@@ -429,6 +465,7 @@ export class VinylPlayer<
         this.drmController.reset()
         this.playbackController.reset()
         this.trackController.reset()
+        this.autoResetController.clear()
         this.dispatch('reset', {})
     }
 

--- a/packages/vinyl/test/unit/track/AutoResetController.test.ts
+++ b/packages/vinyl/test/unit/track/AutoResetController.test.ts
@@ -8,19 +8,36 @@ import {
     type AutoResetControllerImplDeps,
     type AutoResetControllerImplOptions,
 } from '@amazon/vinyl'
-import {
-    ErrorOrigin,
-    ReportableError,
-    networkState,
-    DisposedError,
-} from '@amazon/vinyl-util'
+import { networkState, DisposedError, RequestError } from '@amazon/vinyl-util'
 import { MockPlaybackController } from '@amazon/vinyl/vinylTestUtil'
 import {
     createEventSpy,
+    emptyInternalError,
+    emptyResponseError,
     MockNetworkState,
     overrideGlobalInit,
 } from '@amazon/vinyl-util/testUtil'
 import { mockEvent, useMockTime } from '@amazon/vinyl-util/browserTestUtil'
+
+/**
+ * Creates a RequestError representing a transient network failure (no response received).
+ * These are the only errors that AutoResetController watches for retry opportunities.
+ */
+function createNetworkRequestError(): RequestError {
+    return new RequestError(null, emptyInternalError)
+}
+
+/**
+ * Creates a RequestError that received an HTTP response. These should be ignored by
+ * the AutoResetController, since a service that responded is unlikely to recover
+ * on its own.
+ */
+function createResponseRequestError(): RequestError {
+    return new RequestError(
+        new Response(null, { status: 500 }),
+        emptyResponseError
+    )
+}
 
 describe('AutoResetControllerImpl', () => {
     let deps: AutoResetControllerImplDeps
@@ -86,6 +103,11 @@ describe('AutoResetControllerImpl', () => {
                 jasmine.any(Function)
             )
         })
+
+        it('starts with resetPending false', () => {
+            controller = new AutoResetControllerImpl(deps)
+            expect(controller.resetPending).toBeFalse()
+        })
     })
 
     describe('setError', () => {
@@ -93,59 +115,45 @@ describe('AutoResetControllerImpl', () => {
             controller = new AutoResetControllerImpl(deps)
         })
 
-        it('ignores non-ReportableError', () => {
+        it('ignores non-RequestError', () => {
             const error = new Error('test error')
             controller.setError(error)
             expect(mockNetworkState.on).not.toHaveBeenCalled()
+            expect(controller.resetPending).toBeFalse()
         })
 
-        it('ignores ReportableError with non-SERVICE_INTERNAL origin', () => {
-            const error = new ReportableError(
-                'test',
-                ErrorOrigin.SERVICE_EXTERNAL
-            )
-            controller.setError(error)
+        it('ignores RequestError with a response (HTTP failure)', () => {
+            controller.setError(createResponseRequestError())
             expect(mockNetworkState.on).not.toHaveBeenCalled()
+            expect(controller.resetPending).toBeFalse()
         })
 
-        it('sets error and starts watching for SERVICE_INTERNAL ReportableError', () => {
-            const error = new ReportableError(
-                'test',
-                ErrorOrigin.SERVICE_INTERNAL
-            )
-            controller.setError(error)
+        it('sets error and starts watching for transient network RequestError', () => {
+            controller.setError(createNetworkRequestError())
             expect(mockNetworkState.on).toHaveBeenCalledWith(
                 'online',
                 jasmine.any(Function)
             )
+            expect(controller.resetPending).toBeTrue()
         })
 
         it('ignores subsequent errors when already in error state', () => {
-            const error1 = new ReportableError(
-                'test1',
-                ErrorOrigin.SERVICE_INTERNAL
-            )
-            const error2 = new ReportableError(
-                'test2',
-                ErrorOrigin.SERVICE_INTERNAL
-            )
-
-            controller.setError(error1)
+            controller.setError(createNetworkRequestError())
             mockNetworkState.on.calls.reset()
 
-            controller.setError(error2)
+            controller.setError(createNetworkRequestError())
             expect(mockNetworkState.on).not.toHaveBeenCalled()
         })
     })
 
     describe('reset behavior', () => {
         let resetSpy: jasmine.Spy
-        let error: ReportableError
+        let error: RequestError
 
         beforeEach(() => {
             controller = new AutoResetControllerImpl(deps)
             resetSpy = createEventSpy(controller, 'reset')
-            error = new ReportableError('test', ErrorOrigin.SERVICE_INTERNAL)
+            error = createNetworkRequestError()
         })
 
         it('emits reset event when network comes online', () => {
@@ -238,10 +246,10 @@ describe('AutoResetControllerImpl', () => {
 
     describe('retry interval behavior', () => {
         let resetSpy: jasmine.Spy
-        let error: ReportableError
+        let error: RequestError
 
         beforeEach(() => {
-            error = new ReportableError('test', ErrorOrigin.SERVICE_INTERNAL)
+            error = createNetworkRequestError()
         })
 
         it('retries at specified interval when online', async () => {
@@ -288,14 +296,137 @@ describe('AutoResetControllerImpl', () => {
                 expect(resetSpy).toHaveBeenCalledTimes(3)
             }
         })
+
+        it('clears resetPending when max retries are exhausted', async () => {
+            controller = new AutoResetControllerImpl(deps, {
+                retryInterval: 1,
+                maxRetries: 1,
+            })
+
+            controller.setError(error)
+            expect(controller.resetPending).toBeTrue()
+
+            // First retry succeeds (resets) and re-arms on next setError
+            await clock.tick(1)
+            controller.setError(error)
+            expect(controller.resetPending).toBeTrue()
+
+            // Second retry exhausts the budget — interval fires but no reset emitted,
+            // and resetPending should transition to false.
+            await clock.tick(1)
+            expect(controller.resetPending).toBeFalse()
+        })
     })
 
-    describe('clear', () => {
-        let error: ReportableError
+    describe('resetPending', () => {
+        let error: RequestError
 
         beforeEach(() => {
             controller = new AutoResetControllerImpl(deps)
-            error = new ReportableError('test', ErrorOrigin.SERVICE_INTERNAL)
+            error = createNetworkRequestError()
+        })
+
+        it('is false initially', () => {
+            expect(controller.resetPending).toBeFalse()
+        })
+
+        it('becomes true when an eligible error is set', () => {
+            controller.setError(error)
+            expect(controller.resetPending).toBeTrue()
+        })
+
+        it('remains false when a non-eligible error is set', () => {
+            controller.setError(new Error('not eligible'))
+            expect(controller.resetPending).toBeFalse()
+        })
+
+        it('becomes false after a reset is emitted', () => {
+            controller.setError(error)
+            playbackController.dispatch('play', {})
+            expect(controller.resetPending).toBeFalse()
+        })
+
+        it('becomes false when cleared', () => {
+            controller.setError(error)
+            controller.clear()
+            expect(controller.resetPending).toBeFalse()
+        })
+
+        it('is false when the controller is disabled', () => {
+            controller = new AutoResetControllerImpl(deps, { enabled: false })
+            controller.setError(error)
+            expect(controller.resetPending).toBeFalse()
+        })
+    })
+
+    describe('resetPendingChange event', () => {
+        let resetPendingChangeSpy: jasmine.Spy
+        let error: RequestError
+
+        beforeEach(() => {
+            controller = new AutoResetControllerImpl(deps)
+            resetPendingChangeSpy = createEventSpy(
+                controller,
+                'resetPendingChange'
+            )
+            error = createNetworkRequestError()
+        })
+
+        it('dispatches when resetPending becomes true', () => {
+            controller.setError(error)
+            expect(resetPendingChangeSpy).toHaveBeenCalledOnceWith({
+                previous: false,
+                current: true,
+            })
+        })
+
+        it('dispatches when resetPending becomes false via reset', () => {
+            controller.setError(error)
+            resetPendingChangeSpy.calls.reset()
+
+            playbackController.dispatch('play', {})
+            expect(resetPendingChangeSpy).toHaveBeenCalledOnceWith({
+                previous: true,
+                current: false,
+            })
+        })
+
+        it('dispatches when resetPending becomes false via clear', () => {
+            controller.setError(error)
+            resetPendingChangeSpy.calls.reset()
+
+            controller.clear()
+            expect(resetPendingChangeSpy).toHaveBeenCalledOnceWith({
+                previous: true,
+                current: false,
+            })
+        })
+
+        it('does not dispatch when setError is called with an in-progress error', () => {
+            controller.setError(error)
+            resetPendingChangeSpy.calls.reset()
+
+            controller.setError(error)
+            expect(resetPendingChangeSpy).not.toHaveBeenCalled()
+        })
+
+        it('does not dispatch when clear is called with no error', () => {
+            controller.clear()
+            expect(resetPendingChangeSpy).not.toHaveBeenCalled()
+        })
+
+        it('does not dispatch when an ineligible error is set', () => {
+            controller.setError(new Error('not eligible'))
+            expect(resetPendingChangeSpy).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('clear', () => {
+        let error: RequestError
+
+        beforeEach(() => {
+            controller = new AutoResetControllerImpl(deps)
+            error = createNetworkRequestError()
         })
 
         it('clears error state and stops watching', () => {
@@ -330,11 +461,7 @@ describe('AutoResetControllerImpl', () => {
     describe('dispose', () => {
         it('clears error state and disposes resources', () => {
             controller = new AutoResetControllerImpl(deps)
-            const error = new ReportableError(
-                'test',
-                ErrorOrigin.SERVICE_INTERNAL
-            )
-            controller.setError(error)
+            controller.setError(createNetworkRequestError())
 
             controller.dispose()
 
@@ -361,24 +488,16 @@ describe('AutoResetControllerImpl', () => {
     describe('disabled behavior', () => {
         it('does not watch for errors when disabled', () => {
             controller = new AutoResetControllerImpl(deps, { enabled: false })
-            const error = new ReportableError(
-                'test',
-                ErrorOrigin.SERVICE_INTERNAL
-            )
 
-            controller.setError(error)
+            controller.setError(createNetworkRequestError())
             expect(mockNetworkState.on).not.toHaveBeenCalled()
         })
 
         it('does not emit reset events when disabled', () => {
             controller = new AutoResetControllerImpl(deps, { enabled: false })
             const resetSpy = createEventSpy(controller, 'reset')
-            const error = new ReportableError(
-                'test',
-                ErrorOrigin.SERVICE_INTERNAL
-            )
 
-            controller.setError(error)
+            controller.setError(createNetworkRequestError())
             playbackController.dispatch('play', {})
 
             expect(resetSpy).not.toHaveBeenCalled()

--- a/packages/vinyl/test/unit/vinyl/VinylPlayer.test.ts
+++ b/packages/vinyl/test/unit/vinyl/VinylPlayer.test.ts
@@ -779,6 +779,48 @@ describe('VinylPlayer', () => {
             expect(deps.playbackController.reset).toHaveBeenCalledOnceWith()
             expect(deps.trackController.reset).toHaveBeenCalledOnceWith()
         })
+
+        it('clears auto reset controller on reset', () => {
+            const error = new DrmError('test error')
+            player.dispatch('error', { target: player, error })
+
+            player.reset()
+
+            expect(deps.autoResetController.clear).toHaveBeenCalledOnceWith()
+        })
+
+        describe('resetPending', () => {
+            it('delegates to the auto reset controller', () => {
+                expect(player.resetPending).toBeFalse()
+                deps.autoResetController.resetPending = true
+                expect(player.resetPending).toBeTrue()
+            })
+        })
+
+        describe('resetPendingChange event', () => {
+            it('re-dispatches resetPendingChange events from the auto reset controller', () => {
+                const spy = createEventSpy(player, 'resetPendingChange')
+
+                deps.autoResetController.dispatch('resetPendingChange', {
+                    previous: false,
+                    current: true,
+                })
+                expect(spy).toHaveBeenCalledOnceWith({
+                    previous: false,
+                    current: true,
+                })
+
+                spy.calls.reset()
+                deps.autoResetController.dispatch('resetPendingChange', {
+                    previous: true,
+                    current: false,
+                })
+                expect(spy).toHaveBeenCalledOnceWith({
+                    previous: true,
+                    current: false,
+                })
+            })
+        })
     })
 
     describe('when drmController emits error event', () => {

--- a/packages/vinyl/test/vinylTestUtil/mock/track/MockAutoResetController.ts
+++ b/packages/vinyl/test/vinylTestUtil/mock/track/MockAutoResetController.ts
@@ -17,4 +17,5 @@ export class MockAutoResetController
 {
     setError = spyFactory('setError')
     clear = spyFactory('clear')
+    resetPending = false
 }


### PR DESCRIPTION
Adds a resetPending getter and resetPendingChange event to VinylPlayer so callers can distinguish a transient, automatically-recoverable error (e.g. a network outage) from a terminal one. When resetPending flips to false while error is still non-null, automatic recovery has been exhausted.

AutoResetController now only watches RequestErrors that did not receive a response (pure network failures), since HTTP responses are unlikely to recover on their own. Renames the controller's active/activeChange to resetPending/resetPendingChange to match the public surface, and clears the controller on manual player.reset().
