### PR TITLE
test: increase integ playing event timeout

### DIFF
--- a/packages/vinyl/test/integ/event/playingAndPlayed.test.ts
+++ b/packages/vinyl/test/integ/event/playingAndPlayed.test.ts
@@ -97,8 +97,8 @@ describe('integ playing and played events', () => {
                 await play()
                 playedSpy.calls.reset()
                 playingSpy.calls.reset()
-                const nextPlayed = playedSpy.next()
-                const nextPlaying = playingSpy.next()
+                const nextPlayed = playedSpy.next(15)
+                const nextPlaying = playingSpy.next(15)
                 await player.seekTo(20)
                 await expectAsync(nextPlayed).toBeResolvedTo({
                     started: any(Number),

--- a/packages/vinyl/test/vinylTestUtil/util/playback/expectTrackPlaysUntil.ts
+++ b/packages/vinyl/test/vinylTestUtil/util/playback/expectTrackPlaysUntil.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { onCanPlayThrough, onPlaying, onTimeUpdate } from './eventPromises'
+import { onPlaying, onTimeUpdate } from './eventPromises'
 import { assertFrequency } from '../../media/FrequencyAnalyzer'
 import type { ReadonlyPlaybackController } from '@amazon/vinyl'
 import { sleep } from '@amazon/vinyl-util'
@@ -27,7 +27,6 @@ export async function expectTrackPlaysUntil(
     timeout = 10
 ) {
     await onPlaying(player)
-    await onCanPlayThrough(player)
     // Safari does not always have an updated currentTime after a seeked event. Await the next time update before
     // asserting currentTime values.
     await onTimeUpdate(player)


### PR DESCRIPTION
The playing and played event timeouts for an integ test had too short of a timeout, causing intermittent CI failures for low bandwidth testing.
