### PR TITLE
fix(ci): build vinyl-website before Pages upload in release-publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -19,6 +19,9 @@ jobs:
             contents: write
             id-token: write
             pages: write
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
         steps:
             - uses: actions/checkout@v6
               with:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "test:coverage": "lerna run test:coverage --parallel",
         "pretest:browserstack": "lerna run build:release",
         "test:browserstack": "npm run test:browserstack -ws --if-present",
-        "release": "lerna run lint --concurrency 8 && lerna run test:coverage --concurrency 8 && lerna run analyzeExports --concurrency 8 && npm run prettier:check",
+        "release": "nx run-many -t lint test:coverage build:release analyzeExports --parallel=8 && npm run prettier:check",
         "start": "npm run start -w @amazon/vinyl-website",
         "watch": "lerna run watch --parallel --scope @amazon/*",
         "prepare": "husky"


### PR DESCRIPTION
The release-publish workflow was uploading a non-existent packages/vinyl-website/dist to the Pages artifact step because the release script only ran lint/test/analyzeExports/prettier and never built the website. analyzeExports triggers build:release for publishable packages via nx, but vinyl-website has no analyzeExports target.

Add build:release to the root release script so all package dists — including vinyl-website — are produced, and add the github-pages environment block needed by deploy-pages.
