### PR TITLE
fix(vinyl-tsx): tighten JSX prop typing, simplify setProp null path

### DIFF
--- a/packages/vinyl-tsx/src/extensions/applyStyles.ts
+++ b/packages/vinyl-tsx/src/extensions/applyStyles.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AllowBindable } from '../jsx'
 import { onConnect } from './connectedObserver'
 import { toKebabCase } from '@amazon/vinyl-util'
 import {
@@ -14,9 +13,15 @@ import type { Maybe } from '@amazon/vinyl-util'
 
 /**
  * The shape accepted by the `style` jsx prop. Allows the typed CSSStyleDeclaration
- * fields plus any CSS custom property key (must start with `--`).
+ * fields plus any CSS custom property key (must start with `--`). Null / undefined
+ * clear the CSS property (via setProperty(name, null)), so values are Maybe-wrapped
+ * here even though bindable IDL props reject null.
  */
-export type StyleProp = AllowBindable<Partial<CSSStyleDeclaration>> & {
+export type StyleProp = {
+    [K in keyof Partial<CSSStyleDeclaration>]: MaybeObservableValue<
+        Maybe<CSSStyleDeclaration[K]>
+    >
+} & {
     readonly [customProperty: `--${string}`]: MaybeObservableValue<
         Maybe<string>
     >

--- a/packages/vinyl-tsx/src/jsx.ts
+++ b/packages/vinyl-tsx/src/jsx.ts
@@ -16,51 +16,29 @@ import { applyVisibility } from './extensions/applyVisibility'
 import { applyClassList } from './extensions/applyClassList'
 import type { HookExtension } from './extensions/HookExtension'
 import { passiveEventHandlers } from './extensions/applyPassiveHandler'
-import type { AnyRecord, Maybe } from '@amazon/vinyl-util'
+import type { AnyRecord } from '@amazon/vinyl-util'
 
 /**
- * Maps JS property names to their corresponding HTML attribute names where they differ.
- * Extensible — add entries for custom elements or non-standard properties.
+ * Names like `aria-label` / `role` / `data-*` / any hyphenated prop are DOM
+ * attributes with no matching IDL property — assigning them via `element[k]`
+ * creates an inert expando and the a11y tree / CSS attribute selectors never
+ * see the value. Route those through setAttribute so JSX like
+ * `<div aria-label="foo" />` actually reaches the DOM.
  */
-export const propToAttr: Record<string, string> = {
-    acceptCharset: 'accept-charset',
-    accessKey: 'accesskey',
-    className: 'class',
-    colSpan: 'colspan',
-    contentEditable: 'contenteditable',
-    crossOrigin: 'crossorigin',
-    dateTime: 'datetime',
-    dirName: 'dirname',
-    encType: 'enctype',
-    formAction: 'formaction',
-    formEnctype: 'formenctype',
-    formMethod: 'formmethod',
-    formNoValidate: 'formnovalidate',
-    formTarget: 'formtarget',
-    htmlFor: 'for',
-    httpEquiv: 'http-equiv',
-    inputMode: 'inputmode',
-    maxLength: 'maxlength',
-    minLength: 'minlength',
-    noModule: 'nomodule',
-    noValidate: 'novalidate',
-    readOnly: 'readonly',
-    referrerPolicy: 'referrerpolicy',
-    rowSpan: 'rowspan',
-    tabIndex: 'tabindex',
-    useMap: 'usemap',
+function isAttributeOnlyName(k: string): boolean {
+    return k === 'role' || k.indexOf('-') >= 0
 }
 
 /**
- * Sets a property on an element. When value is non-null, assigns directly via
- * property. When null, resets the property to '' and removes the HTML attribute
- * using the mapped name from {@link propToAttr}.
+ * Sets a property on an element. Hyphenated / aria / role / data names are
+ * assigned as HTML attributes; everything else stays on the property path so
+ * camelCase IDL props (className, tabIndex, onClick, …) keep their existing
+ * fast-path semantics.
  */
 function setProp(element: HTMLElement, k: string, value: unknown): void {
-    if (value == null) {
-        ;(element as any)[k] = ''
-        const attr = propToAttr[k] ?? k
-        element.removeAttribute(attr)
+    if (isAttributeOnlyName(k)) {
+        if (value == null) element.removeAttribute(k)
+        else element.setAttribute(k, String(value))
     } else {
         ;(element as any)[k] = value
     }
@@ -80,7 +58,7 @@ export const hookExtensions = {
 } as const satisfies Record<keyof any, HookExtension<any>>
 
 export type AllowBindable<T> = {
-    [K in keyof T]: MaybeObservableValue<Maybe<T[K]>>
+    [K in keyof T]: MaybeObservableValue<T[K]>
 }
 
 /**

--- a/packages/vinyl-tsx/test/unit/jsx.test.ts
+++ b/packages/vinyl-tsx/test/unit/jsx.test.ts
@@ -65,27 +65,90 @@ describe('jsx', () => {
             expect(el.title).toBe('updated')
         })
 
-        it('removes attribute when observable value becomes null', () => {
+        it('clears nullable IDL props when observable emits null', () => {
+            // onclick is typed as ((...) => any) | null in lib.dom, so null is
+            // a valid runtime value. Regression guard: previously the null
+            // branch coerced through '' and silently poisoned the handler slot
+            // with a string so the event never fired.
             initializeConnectedObserver()
-            const title = data<string | null>('initial')
-            const el = jsx('div', { title }) as MockHTMLDivElement
+            const handler = () => {}
+            const onclick = data<typeof handler | null>(handler)
+            const el = jsx('div', { onclick }) as MockHTMLDivElement
 
             dom.simulateConnect(dom.document, el)
-            el.removeAttribute.calls.reset()
-            title.value = null
-            expect(el.title).toBe('')
-            expect(el.removeAttribute).toHaveBeenCalledWith('title')
+            expect(el.onclick).toBe(handler)
+            onclick.value = null
+            expect(el.onclick).toBeNull()
         })
 
-        it('maps className to class attribute when removing', () => {
+        it('does not call removeAttribute when clearing IDL props', () => {
+            // Reflection on the property clears the attribute; a redundant
+            // removeAttribute would signal the old dual-clear path is back.
             initializeConnectedObserver()
-            const className = data<string | null>('active')
-            const el = jsx('div', { className }) as MockHTMLDivElement
+            const onclick = data<(() => void) | null>(() => {})
+            const el = jsx('div', { onclick }) as MockHTMLDivElement
 
             dom.simulateConnect(dom.document, el)
             el.removeAttribute.calls.reset()
-            className.value = null
-            expect(el.removeAttribute).toHaveBeenCalledWith('class')
+            onclick.value = null
+            expect(el.removeAttribute).not.toHaveBeenCalled()
+        })
+
+        // aria/role/data props are DOM attributes with no IDL property — writing
+        // `el[k] = v` produces an inert expando. Verify setProp routes them via
+        // setAttribute so the a11y tree / attribute selectors actually see them.
+        it('routes aria-* props through setAttribute', () => {
+            const el = jsx('div', {
+                'aria-label': 'Play track',
+            } as any) as MockHTMLDivElement
+            expect(el.setAttribute).toHaveBeenCalledWith(
+                'aria-label',
+                'Play track'
+            )
+        })
+
+        it('routes role through setAttribute', () => {
+            const el = jsx('div', {
+                role: 'button',
+            } as any) as MockHTMLDivElement
+            expect(el.setAttribute).toHaveBeenCalledWith('role', 'button')
+        })
+
+        it('routes data-* props through setAttribute', () => {
+            const el = jsx('div', {
+                'data-testid': 'card',
+            } as any) as MockHTMLDivElement
+            expect(el.setAttribute).toHaveBeenCalledWith('data-testid', 'card')
+        })
+
+        it('coerces non-string aria values to string attributes', () => {
+            const el = jsx('div', {
+                'aria-expanded': true,
+            } as any) as MockHTMLDivElement
+            expect(el.setAttribute).toHaveBeenCalledWith(
+                'aria-expanded',
+                'true'
+            )
+        })
+
+        it('removes aria attribute when observable value becomes null', () => {
+            initializeConnectedObserver()
+            const label = data<string | null>('a')
+            const el = jsx('div', {
+                'aria-label': label,
+            } as any) as MockHTMLDivElement
+
+            dom.simulateConnect(dom.document, el)
+            el.removeAttribute.calls.reset()
+            label.value = null
+            expect(el.removeAttribute).toHaveBeenCalledWith('aria-label')
+        })
+
+        it('keeps camelCase IDL properties on the property path', () => {
+            // tabIndex is a real IDL property — regressing this to setAttribute
+            // would break code that reads `el.tabIndex` synchronously.
+            const el = jsx('div', { tabIndex: 3 }) as MockHTMLDivElement
+            expect((el as any).tabIndex).toBe(3)
         })
 
         it('delegates hook extension properties', () => {

--- a/packages/vinyl-tsx/test/unit/jsxMarkup.test.tsx
+++ b/packages/vinyl-tsx/test/unit/jsxMarkup.test.tsx
@@ -1,0 +1,32 @@
+import { jsx } from '@amazon/vinyl-tsx'
+import { installDomPolyfill } from './domPolyfill'
+import { data } from '@amazon/vinyl-observable'
+
+describe('jsxMarkup', () => {
+    installDomPolyfill()
+
+    describe('tsx elements', () => {
+        it('are compile-time safe', () => {
+            const d = <div id="test123" />
+            expect(d.id).toBe('test123')
+
+            // @ts-expect-error Expected notValid to be compile-time failure
+            const _d2 = <div notValid="123" />
+
+            const _d3 = <div aria-controls="123" />
+            const _d4 = <div aria-any-valid="123" />
+            const _d5 = <div data-any-valid="123" />
+            const _d6 = <div any-dash-valid="123" />
+            // @ts-expect-error Expected non-nullable
+            const _d7 = <div tabIndex={null} />
+            // @ts-expect-error Expected non-nullable
+            const _d8 = <div tabIndex={data<number | null>(0)} />
+            // @ts-expect-error Expected number
+            const _d9 = <div tabIndex="1" />
+            // @ts-expect-error Expected number
+            const _d9 = <div tabIndex={data('1')} />
+            const _d10 = <div tabIndex={data(1)} />
+            const _d11 = <div tabIndex={1} />
+        })
+    })
+})

--- a/packages/vinyl-tsx/test/unit/tsconfig.json
+++ b/packages/vinyl-tsx/test/unit/tsconfig.json
@@ -3,7 +3,10 @@
     "include": ["./**/*"],
     "compilerOptions": {
         "outDir": "../../dist/unit/types/current",
-        "noEmit": true
+        "noEmit": true,
+        "jsx": "preserve",
+        "jsxFactory": "jsx",
+        "jsxFragmentFactory": "Fragment"
     },
     "references": [
         {

--- a/packages/vinyl-tsx/tsconfig.lint.json
+++ b/packages/vinyl-tsx/tsconfig.lint.json
@@ -1,7 +1,10 @@
 {
     "extends": "../../tsconfig.test.json",
     "compilerOptions": {
-        "noEmit": true
+        "noEmit": true,
+        "jsx": "preserve",
+        "jsxFactory": "jsx",
+        "jsxFragmentFactory": "Fragment"
     },
     "include": ["src/**/*", "test/**/*", "buildSrc/**/*", "buildScripts/**/*"]
 }

--- a/packages/vinyl-website/tsconfig.json
+++ b/packages/vinyl-website/tsconfig.json
@@ -4,7 +4,7 @@
         "module": "ESNext",
         "moduleResolution": "bundler",
         "customConditions": ["development"],
-        "jsx": "react",
+        "jsx": "preserve",
         "jsxFactory": "jsx",
         "jsxFragmentFactory": "Fragment",
         "strict": true,


### PR DESCRIPTION
setProp previously assigned '' when an observable-bound prop emitted null, regardless of the IDL prop's type. For function props (onclick, etc.) that silently poisoned the handler slot with a string so the event never fired. It also always followed up with a removeAttribute call, using a hand-maintained propToAttr map that was easy to forget when adding new type-safe props.

Rather than coerce at runtime, close the hole in the type surface: AllowBindable no longer wraps values in Maybe<>, so nullable observables can't be bound to non-nullable IDL props at all. tabIndex={null} is now a compile error (clearing to 0 would be astonishing); nullable props like onclick still accept null because lib.dom types them that way. setProp becomes a direct property assignment and the propToAttr export is dropped.

StyleProp keeps its Maybe-wrapping because setProperty(name, null) is the CSS "unset" contract — null is semantically valid there.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
