### PR TITLE
fix(vinyl-tsx): change props to default to empty object when null

### DIFF
--- a/packages/vinyl-tsx/src/jsx.ts
+++ b/packages/vinyl-tsx/src/jsx.ts
@@ -128,7 +128,7 @@ export function jsx(type: any, props: any, ...children: any) {
         )
         return element
     } else {
-        return type(props, children)
+        return type(props ?? {}, children)
     }
 }
 

--- a/packages/vinyl-tsx/test/unit/jsx.test.ts
+++ b/packages/vinyl-tsx/test/unit/jsx.test.ts
@@ -185,6 +185,17 @@ describe('jsx', () => {
 
             expect(jsx(factory, {})).toBe(result)
         })
+
+        it('defaults null props to an empty object', () => {
+            const factory = createSpy<
+                (
+                    props: Record<string, unknown>,
+                    children: unknown[]
+                ) => HTMLElement
+            >('factory').and.returnValue(dom.createElement('div'))
+            jsx(factory, null as unknown as Record<string, unknown>)
+            expect(factory).toHaveBeenCalledWith({}, [])
+        })
     })
 
     describe('Fragment', () => {


### PR DESCRIPTION
Typescript versions differ whether TSX provides null or an empty object to props. Default to an empty object when null.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
