### PR TITLE
refactor(vinyl-tsx): return Unsubscribe from applyClassList

### DIFF
--- a/packages/vinyl-tsx/reports/treeShaking/vinyl-tsx.json
+++ b/packages/vinyl-tsx/reports/treeShaking/vinyl-tsx.json
@@ -1,3 +1,3 @@
 {
-  "minBundleSize": 2015
+  "minBundleSize": 3102
 }

--- a/packages/vinyl-tsx/src/extensions/applyClassList.ts
+++ b/packages/vinyl-tsx/src/extensions/applyClassList.ts
@@ -8,25 +8,29 @@ import {
     type ObservableValue,
 } from '@amazon/vinyl-observable'
 import { onConnect } from './connectedObserver'
-import type { Maybe, Unsubscribe } from '@amazon/vinyl-util'
+import {
+    createDisposer,
+    noop,
+    type Maybe,
+    type Unsubscribe,
+} from '@amazon/vinyl-util'
 
 export function applyClassList(
     element: HTMLElement,
     classList: readonly (Maybe<string> | ObservableValue<Maybe<string>>)[]
-): void {
+): Unsubscribe {
     const tokens = classList.filter((s) => typeof s === 'string')
     element.classList.add(...tokens)
     if (tokens.length < classList.length) {
-        onConnect(element, () => {
-            const subs: Unsubscribe[] = []
+        return onConnect(element, () => {
+            const { add, dispose } = createDisposer()
             for (const dP of classList.filter(isObservableValue)) {
-                subs.push(bindClass(element, dP))
+                add(bindClass(element, dP))
             }
-            return () => {
-                subs.forEach((sub) => sub())
-            }
+            return dispose
         })
     }
+    return noop
 }
 
 function bindClass(

--- a/packages/vinyl-tsx/test/unit/extensions/applyClassList.test.ts
+++ b/packages/vinyl-tsx/test/unit/extensions/applyClassList.test.ts
@@ -93,6 +93,29 @@ describe('applyClassList', () => {
         expect(el.classList.contains('dynamic')).toBeTrue()
     })
 
+    it('returns a callable unsubscribe for a static-only list', () => {
+        const el = dom.createElement('div')
+        const unsub = applyClassList(el, ['foo', 'bar'])
+        expect(unsub).toEqual(jasmine.any(Function))
+        expect(() => unsub()).not.toThrow()
+    })
+
+    it('unsubscribes observable bindings via the returned unsubscribe', () => {
+        initializeConnectedObserver()
+        const el = dom.createElement('div')
+        const className = data<string | null>('active')
+
+        const unsub = applyClassList(el, [className])
+        dom.simulateConnect(dom.document, el)
+        expect(el.classList.contains('active')).toBeTrue()
+
+        unsub()
+        expect(el.classList.contains('active')).toBeFalse()
+
+        className.value = 'new-class'
+        expect(el.classList.contains('new-class')).toBeFalse()
+    })
+
     it('does not remove a re-added class on cleanup after null transition', () => {
         initializeConnectedObserver()
         const el = dom.createElement('div')


### PR DESCRIPTION
Return an Unsubscribe from applyClassList: the one from onConnect when there are observable classes to bind, or noop when onConnect is never called (static-only list). Replace the manual subs array with the vinyl-util createDisposer convention (add/dispose).

Add tests covering the returned unsubscribe for both the static-only (noop) and observable-binding paths.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
