### PR TITLE
chore: remove unused VinylDeps.media

### DIFF
--- a/packages/vinyl/src/vinyl/VinylDeps.ts
+++ b/packages/vinyl/src/vinyl/VinylDeps.ts
@@ -52,10 +52,4 @@ export interface VinylDeps<
      * Notifies when playback can automatically reset after a failure.
      */
     readonly autoResetController: AutoResetController
-
-    /**
-     * The HTML media element. Used by track factories to attach sidecar text
-     * tracks via `addTextTrack`.
-     */
-    readonly media: HTMLMediaElement
 }


### PR DESCRIPTION
VinylPlayer itself doesn't depend directly on media

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
