### PR TITLE
fix(playback): prevent a metadata-deferred seek from clobbering a new seek

### DIFF
--- a/packages/vinyl/src/playback/PlaybackControllerImpl.ts
+++ b/packages/vinyl/src/playback/PlaybackControllerImpl.ts
@@ -114,6 +114,9 @@ export class PlaybackControllerImpl
     private _seeking = false
     private _waiting = false
 
+    // Monotonic counter identifying the most recent seekTo call.
+    private _seekId = 0
+
     // default user volume (0.0 to 1.0 scale)
     private userVolume: number = 1.0
     private _pendingPlay: Promise<void> | null = null
@@ -597,6 +600,14 @@ export class PlaybackControllerImpl
 
     async seekTo(time: number, tolerance = 0.5): Promise<void> {
         logDebug(this, `seekTo: ${time}`)
+        // Claim this seek as the newest. A seek that parks on an await (e.g. waiting for loadedMetadata) can resume
+        // AFTER a later-issued seek has already applied its target.
+        const seekId = ++this._seekId
+        const superseded = (): boolean => {
+            if (this._seekId === seekId) return false
+            logDebug(this, `seekTo: ${time} superseded by a newer seek`)
+            return true
+        }
         const nextEvent = <K extends keyof PlaybackControllerEventMap>(
             type: K
         ): Promise<PlaybackControllerEventMap[K]> => {
@@ -615,6 +626,9 @@ export class PlaybackControllerImpl
         // Cannot seek until there are seekable ranges.
         if (!this.hasMetadata) {
             await nextEvent('loadedMetadata')
+            // A newer seek was issued while we waited — it already applied (or
+            // will apply) its target. Don't overwrite it with this stale one.
+            if (superseded()) return
         }
 
         const seekable = this.seekable

--- a/packages/vinyl/test/unit/playback/PlaybackControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/playback/PlaybackControllerImpl.test.ts
@@ -267,6 +267,32 @@ describe('PlaybackController', () => {
                     expect(media.currentTime).toBe(3)
                 })
 
+                it('does not let a metadata-deferred seek clobber a newer seek', async () => {
+                    // Reproduces the real race: the activate-time seek to the
+                    // track start parks waiting for the `loadedmetadata` EVENT.
+                    // Meanwhile readyState reaches HAVE_METADATA, so a
+                    // later-issued seek proceeds immediately and applies its
+                    // target. When the `loadedmetadata` event finally fires, the
+                    // parked stale seek must NOT reset the position back over the
+                    // newer target — it resolves as a no-op and the newer wins.
+                    enableSeekAutoComplete()
+                    // Stale seek parks: no metadata yet.
+                    const stale = controller.seekTo(0)
+                    // Metadata becomes available (readyState) WITHOUT the event
+                    // dispatching yet, so the next seek does not park.
+                    media.readyState = PlaybackReadyState.HAVE_METADATA
+                    media.duration = 10
+                    media.seekable = new MockTimeRanges([[0, 10]])
+                    const newer = controller.seekTo(3)
+                    await expectAsync(newer).toBeResolved()
+                    expect(media.currentTime).toBe(3)
+                    // Now the deferred event fires and the stale seek resumes.
+                    media.dispatchEvent(mockEvent('loadedmetadata'))
+                    await expectAsync(stale).toBeResolved()
+                    // The stale seek did not clobber the newer target back to 0.
+                    expect(media.currentTime).toBe(3)
+                })
+
                 it('constrains seeks to allowable ranges within tolerance', async () => {
                     const minSeekableBuffer =
                         controller.options.minSeekableBuffer


### PR DESCRIPTION
When seekTo() is called before the media has metadata, it parks on the `loadedmetadata` event. If a later seek is issued after readyState reaches HAVE_METADATA but before that event dispatches, the newer seek proceeds immediately and applies its target — then the parked stale seek resumes on the event and resets currentTime back to its own (older) target, clobbering the newer position.

This surfaced on slow networks (BrowserStack): the activate-time seekTo(0) parked, the test's seekTo(21) applied, then the stale seekTo(0) resumed on loadedmetadata and reset playback to 0. Content then played from 0 and never reached the 20s ad break before the spec timeout. Fast networks dispatch loadedmetadata before the second seek, so the bug is invisible locally.

Tag each seekTo with a monotonic generation; after awaiting metadata, bail as a no-op resolution if a newer seek has superseded it. Adds a unit test reproducing the exact readyState-set-before-event ordering.
