### PR TITLE
test(integ): give browserstack runs more request retries

### DIFF
--- a/packages/vinyl/test/vinylTestUtil/player/createVinylSuite.ts
+++ b/packages/vinyl/test/vinylTestUtil/player/createVinylSuite.ts
@@ -11,9 +11,12 @@ import {
 import type { Unsubscribe } from '@amazon/vinyl-util'
 import {
     createLogPrefix,
+    createRequester,
     getGlobalRegistry,
     IllegalStateError,
     logDebug,
+    requesterWithRetryRef,
+    RetryStrategy,
 } from '@amazon/vinyl-util'
 import { setTestTimeout } from '@amazon/vinyl-util/browserTestUtil'
 import { mediaRef } from './mediaRef'
@@ -69,6 +72,13 @@ export class VinylSuite<T extends VinylPlayer<any, any> = VinylPlayer> {
         let playerErrorSub: Unsubscribe | null = null
         setTestTimeout(this.options?.timeout ?? 60)
         beforeEach(() => {
+            // Browserstack's network is flaky and prone to transient drops;
+            // give integ requests more retries than the production default.
+            requesterWithRetryRef.set(() =>
+                createRequester({
+                    retryOptions: { ...RetryStrategy.ONE_RETRY, retries: 3 },
+                })
+            )
             document.addEventListener(
                 'visibilitychange',
                 this.visibilityChangeHandler


### PR DESCRIPTION
Browserstack's network is flaky and drops the occasional request, failing otherwise-passing specs. Bump the request retry count from the production default (ONE_RETRY) to 3 for the integ player suite by overriding requesterWithRetryRef in createVinylSuite's per-spec beforeEach (reset along with the rest of the global registry in afterEach). Scoped to integ; production retry behavior and the request timeout are unchanged.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
