### PR TITLE
fix: guard controllers against logging after disposal

### DIFF
--- a/packages/vinyl/src/ad/AdControllerImpl.ts
+++ b/packages/vinyl/src/ad/AdControllerImpl.ts
@@ -10,6 +10,7 @@ import {
     lerp,
     logDebug,
     type Maybe,
+    noop,
     resolveValueProvider,
     roundToNearest,
     sleep,
@@ -366,6 +367,7 @@ export class AdControllerImpl
             .catch(() => undefined)
         resolveValueProvider(value?.ads)
             .then((ads) => {
+                if (this.disposed) return
                 if (this._currentAdBreak !== value) return
                 const adsList = ads?.slice() ?? []
                 this.pendingAds = adsList
@@ -420,15 +422,18 @@ export class AdControllerImpl
             index: this._currentAdIndex,
             totalAds: this._totalAds,
         })
-        void sleep(this.options.adLoadTimeout).then(() => {
-            if (this.adStats === stats && !stats.playing) {
-                this.failAd(
-                    new AdError(
-                        `Ad failed to start after ${this.options.adLoadTimeout} seconds`
+        sleep(this.options.adLoadTimeout)
+            .then(() => {
+                if (this.disposed) return
+                if (this.adStats === stats && !stats.playing) {
+                    this.failAd(
+                        new AdError(
+                            `Ad failed to start after ${this.options.adLoadTimeout} seconds`
+                        )
                     )
-                )
-            }
-        })
+                }
+            })
+            .catch(noop)
     }
 
     private completeAd(reason: AdChangeReason) {

--- a/packages/vinyl/src/drm/DrmControllerImpl.ts
+++ b/packages/vinyl/src/drm/DrmControllerImpl.ts
@@ -170,6 +170,7 @@ export class DrmControllerImpl
                     params.keySystem,
                     [params.config]
                 )
+                this.abortIfDisposed()
                 logVerbose(
                     this,
                     'requestMediaKeySystemAccess supported',
@@ -181,7 +182,12 @@ export class DrmControllerImpl
                         params.config.persistentState === 'required',
                 }
             } catch (_) {
-                logVerbose(this, 'requestMediaKeySystemAccess rejected', params)
+                if (!this.disposed)
+                    logVerbose(
+                        this,
+                        'requestMediaKeySystemAccess rejected',
+                        params
+                    )
                 return { supported: false, persistentState: false }
             }
         },
@@ -236,6 +242,7 @@ export class DrmControllerImpl
                 this.abortIfDisposed()
                 this.mediaKeys = mediaKeys
                 await mediaKeys.setOnElement(this.deps.media)
+                this.abortIfDisposed()
                 logDebug(this, `set media keys on element`)
                 this.dispatch('mediaKeysSet', {
                     keySystem: mediaKeys.keySystem,
@@ -293,6 +300,7 @@ export class DrmControllerImpl
             })
             newSession.on('closed', () => this.closeSession(newSession))
             abort?.onAborted(() => {
+                if (this.disposed) return
                 logDebug(this, 'abort session')
                 this.closeSession(newSession)
             })
@@ -372,11 +380,13 @@ export class DrmControllerImpl
                         keySystem,
                         [config]
                     )
-                logDebug(
-                    this,
-                    `created media key system access for keySystem: ${access.keySystem}}`,
-                    config
-                )
+                if (!this.disposed) {
+                    logDebug(
+                        this,
+                        `created media key system access for keySystem: ${access.keySystem}}`,
+                        config
+                    )
+                }
                 return access
             } catch (_) {
                 // ignore
@@ -491,6 +501,7 @@ export class DrmControllerImpl
             defaultInitDataTransformer(mediaKeys.keySystem, certBytes)
         initData = transform(bufferToByteArray(initData), initDataType, drmInfo)
 
+        this.abortIfDisposed()
         logDebug(this, 'createSession', drmInfo.mimeType, initDataType)
         const session = mediaKeys.createSession(
             drmInfo.mimeType,
@@ -535,6 +546,7 @@ export class DrmControllerImpl
         const licenseServerOptions =
             clone(await resolveValueProvider(licenseServerOptionsProvider)) ??
             {}
+        this.abortIfDisposed()
 
         let challenge: BodyInit = event.message
         if (isPlayReady(keySystem)) {
@@ -574,6 +586,10 @@ export class DrmControllerImpl
     }
 
     private closeSession(session: CommonMediaKeySession) {
+        // Sessions are closed synchronously during dispose() (before the
+        // disposer flips `disposed`), but a session's own async 'closed'/'error'
+        // can arrive after teardown.
+        if (this.disposed) return
         logDebug(this, 'closeSession')
         session.dispose()
         remove(this.sessions, session)

--- a/packages/vinyl/src/streaming/buffering/MediaSourceController.ts
+++ b/packages/vinyl/src/streaming/buffering/MediaSourceController.ts
@@ -224,6 +224,10 @@ export class MediaSourceControllerImpl
         if (!this.active) return
         this.activateDisposer!.dispose()
         this.activateDisposer = null
+        // Invalidate any in-flight refreshDuration so its continuation returns
+        // at the token check rather than setting duration (and logging) after
+        // deactivation.
+        ++this.durationToken
         try {
             URL.revokeObjectURL(this.objectUrl!)
         } catch (error) {

--- a/packages/vinyl/src/track/TrackController.ts
+++ b/packages/vinyl/src/track/TrackController.ts
@@ -612,6 +612,9 @@ export class TrackControllerImpl<TrackLoadOptionsType extends TrackLoadOptions>
                                 )
                             })
                             .catch((error) => {
+                                // The provider (a HEAD probe) isn't canceled on
+                                // dispose; don't log after teardown.
+                                if (this.disposed) return
                                 logWarn(
                                     this,
                                     'failed to resolve ad track load options for preload',
@@ -621,6 +624,9 @@ export class TrackControllerImpl<TrackLoadOptionsType extends TrackLoadOptions>
                     }
                 })
                 .catch((error) => {
+                    // The ads provider may fetch and isn't canceled on dispose;
+                    // don't log after teardown.
+                    if (this.disposed) return
                     logWarn(this, 'failed to resolve ads for preload', error)
                 })
         }

--- a/packages/vinyl/test/integ/playback/reset.test.ts
+++ b/packages/vinyl/test/integ/playback/reset.test.ts
@@ -16,14 +16,12 @@ import type {
     RequestOptions,
 } from '@amazon/vinyl-util'
 import {
-    createRequester,
     networkState,
     noop,
     type Requester,
     RequestError,
     requesterWithRetryRef,
     RequestFailureType,
-    RetryStrategy,
     sleep,
 } from '@amazon/vinyl-util'
 import { createVinylSuite, vinylTestAssets } from '@amazon/vinyl/vinylTestUtil'
@@ -43,40 +41,6 @@ import { normalizeHeadersInit } from '@amazon/vinyl-util'
 const playbackTime = 5
 
 describe('reset integ', () => {
-    overrideGlobalInit(requesterWithRetryRef, () => {
-        const requester = createRequester({
-            retryOptions: RetryStrategy.ONE_RETRY,
-        })
-        const originalRequest = requester.request.bind(requester)
-        spyOn(requester, 'request').and.callFake(
-            async (
-                input: RequestInfo | Readonly<URL>,
-                init?: Maybe<RequestInitOptions>,
-                requestOptions?: Maybe<RequestOptions>
-            ) => {
-                if (!requestGate(input, init, requestOptions)) {
-                    await sleep(0.1)
-                    throw new RequestError(null, {
-                        ok: false,
-                        type: RequestFailureType.INTERNAL,
-                        willRetry: false,
-                        retryAfter: null,
-                        reason: null,
-                        timestamp: Date.now(),
-                        requestInfo: {
-                            ...emptyRequestInfo,
-                            init: init ?? emptyRequestInfo.init,
-                            input,
-                        },
-                    })
-                }
-                return originalRequest(input, init, requestOptions)
-            }
-        )
-
-        return requester
-    })
-
     let mockNetworkState: MockNetworkState
     const mockNetworkStateRef = overrideGlobalInit(
         networkState,
@@ -111,6 +75,40 @@ describe('reset integ', () => {
     let failNext: boolean
 
     beforeEach(() => {
+        // Spy on the requester the suite actually configures (createVinylSuite
+        // registers an earlier `beforeEach` that overrides requesterWithRetryRef
+        // for BrowserStack retries). Spying on the initialized instance here —
+        // rather than racing another `set()` override, which the suite's would
+        // clobber — guarantees this failure-injection gate is what the player
+        // uses while preserving the suite's requester configuration.
+        const requester = requesterWithRetryRef.value
+        const originalRequest = requester.request.bind(requester)
+        spyOn(requester, 'request').and.callFake(
+            async (
+                input: RequestInfo | Readonly<URL>,
+                init?: Maybe<RequestInitOptions>,
+                requestOptions?: Maybe<RequestOptions>
+            ) => {
+                if (!requestGate(input, init, requestOptions)) {
+                    await sleep(0.1)
+                    throw new RequestError(null, {
+                        ok: false,
+                        type: RequestFailureType.INTERNAL,
+                        willRetry: false,
+                        retryAfter: null,
+                        reason: null,
+                        timestamp: Date.now(),
+                        requestInfo: {
+                            ...emptyRequestInfo,
+                            init: init ?? emptyRequestInfo.init,
+                            input,
+                        },
+                    })
+                }
+                return originalRequest(input, init, requestOptions)
+            }
+        )
+
         mockNetworkState = mockNetworkStateRef.value
         mockNetworkState.onLine = true
         failNext = false

--- a/packages/vinyl/test/unit/ad/AdControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/ad/AdControllerImpl.test.ts
@@ -1143,6 +1143,48 @@ describe('AdControllerImpl', () => {
         })
     })
 
+    describe('disposal during pending async work', () => {
+        it('ignores a break ad list that resolves after disposal', async () => {
+            const c = createController()
+            let resolveAds: (ads: readonly AdInfo[]) => void = () => {}
+            c.setAds(
+                trackAds(
+                    makeBreak({
+                        startTime: 10,
+                        ads: () =>
+                            new Promise<readonly AdInfo[]>((resolve) => {
+                                resolveAds = resolve
+                            }),
+                    })
+                )
+            )
+            updateTime(10)
+            c.dispose()
+            resolveAds([defaultAd])
+            await flush()
+            expect(c.currentAd).toBeNull()
+        })
+
+        it('does not fail an ad after disposal when the load timeout elapses', async () => {
+            // A small non-zero timeout so the timer is a real setTimeout that
+            // fires after we dispose (sleep(0) would resolve on a microtask,
+            // before dispose).
+            const c = new AdControllerImpl(
+                { playbackController },
+                { adLoadTimeout: 0.001 }
+            )
+            const errors: unknown[] = []
+            c.on('adError', (e) => errors.push(e.error))
+            c.setAds(trackAds(makeBreak({ startTime: 0, duration: 10 })))
+            updateTime(1)
+            await flush()
+            // Dispose before the load-timeout timer fires.
+            c.dispose()
+            await new Promise((resolve) => setTimeout(resolve, 5))
+            expect(errors).toEqual([])
+        })
+    })
+
     describe('dispose', () => {
         it('stops responding to time updates', async () => {
             const c = createController()

--- a/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
@@ -444,6 +444,21 @@ describe('DrmControllerImpl', () => {
                 ).toEqual([1, 1, 1, 1, 1, 1]) // Expect all sessions to have been disposed
                 expect(drmController.activeSessions).toEqual(0)
             })
+
+            it('ignores a session that closes or aborts after disposal', async () => {
+                const abort = new Abort()
+                drmController.setBufferingDrmInfo(drmInfo, abort)
+                await emitEncrypted(new Uint8Array([1]))
+                const session = mediaKeys.createSession.calls.mostRecent()
+                    .returnValue as MockCommonMediaKeySession
+                drmController.dispose()
+                session.dispose.calls.reset()
+                // A late 'closed' and a late abort must be ignored after
+                // teardown (no re-close, no post-dispose log).
+                session.dispatch('closed', { reason: 'closed-by-application' })
+                abort.abort()
+                expect(session.dispose).not.toHaveBeenCalled()
+            })
         })
     })
 
@@ -1349,6 +1364,26 @@ describe('DrmControllerImpl', () => {
                 DrmKeySystem.WIDEVINE,
                 DrmKeySystem.PLAY_READY,
             ])
+        })
+
+        it('does not log a support result after disposal', async () => {
+            // A memoized probe still in flight when the controller is disposed
+            // must resolve inertly without logging its result post-teardown.
+            let resolveAccess: (
+                a: MockCommonMediaKeySystemAccess
+            ) => void = () => {}
+            commonEme.requestMediaKeySystemAccess.and.returnValue(
+                new Promise<MockCommonMediaKeySystemAccess>((resolve) => {
+                    resolveAccess = resolve
+                })
+            )
+            const supported = drmController.isSupported(drmInfo)
+            drmController.dispose()
+            resolveAccess(access)
+            await expectAsync(supported).toBeResolvedTo({
+                supported: false,
+                persistentState: false,
+            })
         })
     })
 

--- a/packages/vinyl/test/unit/track/TrackController.test.ts
+++ b/packages/vinyl/test/unit/track/TrackController.test.ts
@@ -1404,6 +1404,70 @@ describe('TrackControllerImpl', () => {
 
             expect(tc.isTrackCached('https://ads/late.m3u8')).toBeFalse()
         })
+
+        it('does not throw when ad options reject after disposal', async () => {
+            // The HEAD-probe provider isn't cancelled on dispose; a rejection
+            // after teardown must hit the guard, not log.
+            let rejectOptions: (error: Error) => void = () => {}
+            const tc = new TrackControllerImpl<TrackLoadOptions>({
+                ...deps,
+                adTrackLoadOptionsProvider: () =>
+                    new Promise<TrackLoadOptions>((_resolve, reject) => {
+                        rejectOptions = reject
+                    }),
+            })
+            const [main] = createLoadOptionsList(1)
+            tc.load(main)
+            const track = tc.currentTrack as MockTrack
+            const ads = trackAdsWith(main.uri, 'https://ads/late.m3u8')
+            track.ads = ads
+            track.dispatch('adsChange', { previous: null, current: ads })
+            await flushAds()
+
+            tc.dispose()
+            rejectOptions(new Error('boom'))
+            await flushAds()
+
+            expect(tc.disposed).toBeTrue()
+            expect(tc.isTrackCached('https://ads/late.m3u8')).toBeFalse()
+        })
+
+        it("does not throw when a break's ad list rejects after disposal", async () => {
+            let rejectAds: (error: Error) => void = () => {}
+            const tc = new TrackControllerImpl<TrackLoadOptions>(deps)
+            const [main] = createLoadOptionsList(1)
+            tc.load(main)
+            const track = tc.currentTrack as MockTrack
+            const ads = {
+                trackUri: main.uri,
+                adBreaks: [
+                    {
+                        id: 'b1',
+                        startTime: 5,
+                        duration: 10,
+                        placement: 'midroll' as const,
+                        restrict: {},
+                        once: false,
+                        resumeOffset: null,
+                        playoutLimit: null,
+                        skipControl: () => null,
+                        ads: () =>
+                            new Promise<readonly []>((_resolve, reject) => {
+                                rejectAds = reject
+                            }),
+                    },
+                ],
+            }
+            track.ads = ads
+            track.dispatch('adsChange', { previous: null, current: ads })
+            await flushAds()
+
+            tc.dispose()
+            rejectAds(new Error('ad list down'))
+            await flushAds()
+
+            expect(tc.disposed).toBeTrue()
+        })
     })
 
     describe('ad track lifecycle', () => {


### PR DESCRIPTION
Async continuations (response-failure catches, resolve/timeout callbacks, session events) were logging via loggerRef after the initiating controller was disposed — which re-initializes the reset global logger and breaks test isolation. Guard each so the log can't fire post-teardown:

- TrackController: both ad-preload catches (HEAD probe + ad-list provider) return early when disposed.
- AdControllerImpl: the ad-list resolve continuation and the (uncancelled) load-timeout sleep return early when disposed.
- DrmControllerImpl: abortIfDisposed() after the awaits in checkIsSupportedCached / attachMediaKeys / createNewSession / messageHandler (PlayReady unpack); a log-guard in createAccess (its loop catch would swallow an abort); and disposed guards in closeSession (a session's late 'closed'/'error') and the session abort handler.
- MediaSourceController: deactivate() bumps durationToken so an in-flight refreshDuration returns at the existing token check instead of setting duration (and logging).

Adds tests covering each new disposed branch; 100% coverage maintained.

Not fixed here: requesterUtil.parseRetryAfter logs a malformed Retry-After via a global target with no controller/disposal signal — only the systemic logger change would cover it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
