### PR TITLE
fix(hls): bound variable-name pattern to prevent ReDoS

### DIFF
--- a/packages/vinyl-hls-parser/src/parse/parseMediaPlaylist.ts
+++ b/packages/vinyl-hls-parser/src/parse/parseMediaPlaylist.ts
@@ -12,7 +12,11 @@ import type { HlsMediaPlaylist } from '../types/HlsMediaPlaylist'
 import { parseAttributes } from './parseAttributes'
 import { readLine, skipWhitespaceLine, addIfPresent } from './parseUtil'
 
-export const HLS_VARIABLE_PATTERN = /\{\$([^}]+)}/g
+// The variable-name class excludes `{` (and `}`) so a match attempt can't
+// scan across token boundaries. With `[^}]` a crafted value such as
+// `{$|{$|{$|…` makes replace() do polynomial work (ReDoS); `[^{}]` keeps it
+// linear, and HLS variable names never contain `{`/`}`.
+export const HLS_VARIABLE_PATTERN = /\{\$([^{}]+)}/g
 
 const EXTM3U = '#EXTM3U'
 const EXTINF = '#EXTINF:'

--- a/packages/vinyl-hls-parser/test/unit/parse/parseMediaPlaylist.test.ts
+++ b/packages/vinyl-hls-parser/test/unit/parse/parseMediaPlaylist.test.ts
@@ -727,4 +727,22 @@ describe('substituteVariables', () => {
     it('returns string unchanged when no variables', () => {
         expect(substitute('no-vars', {}, HLS_VARIABLE_PATTERN)).toBe('no-vars')
     })
+
+    it('does not scan a variable name across a token boundary', () => {
+        // The name class excludes '{', so a malformed prefix cannot swallow a
+        // following valid reference; only the inner '{$foo}' is substituted.
+        expect(
+            substitute('{$|{$foo}', { foo: 'X' }, HLS_VARIABLE_PATTERN)
+        ).toBe('{$|X')
+    })
+
+    it('stays linear on adversarial input (ReDoS guard)', () => {
+        // Repeated '{$|' forms no complete '{$name}' reference, so the input is
+        // returned unchanged. With a '[^}]' name class this scanned across '{'
+        // boundaries and ran in polynomial time; '[^{}]' keeps it linear.
+        const input = '{$|'.repeat(100_000)
+        const start = Date.now()
+        expect(substitute(input, {}, HLS_VARIABLE_PATTERN)).toBe(input)
+        expect(Date.now() - start).toBeLessThan(1000)
+    })
 })


### PR DESCRIPTION
HLS_VARIABLE_PATTERN used [^}]+ for the variable name, so the capture could scan across '{' and '$' boundaries. On crafted playlist input such as '{$|{$|{$|…', substitute()'s replace() did polynomial (O(n^2)) work. Excluding '{' (and '}') from the name class keeps each match attempt bounded to a single '{$…}' token, making it linear. HLS variable names never contain '{' or '}', so valid references are unaffected.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
