### PR TITLE
Fix/ads

### DIFF
--- a/packages/vinyl-hls-parser/src/parse/parseMediaPlaylist.ts
+++ b/packages/vinyl-hls-parser/src/parse/parseMediaPlaylist.ts
@@ -12,7 +12,11 @@ import type { HlsMediaPlaylist } from '../types/HlsMediaPlaylist'
 import { parseAttributes } from './parseAttributes'
 import { readLine, skipWhitespaceLine, addIfPresent } from './parseUtil'
 
-export const HLS_VARIABLE_PATTERN = /\{\$([^}]+)}/g
+// The variable-name class excludes `{` (and `}`) so a match attempt can't
+// scan across token boundaries. With `[^}]` a crafted value such as
+// `{$|{$|{$|…` makes replace() do polynomial work (ReDoS); `[^{}]` keeps it
+// linear, and HLS variable names never contain `{`/`}`.
+export const HLS_VARIABLE_PATTERN = /\{\$([^{}]+)}/g
 
 const EXTM3U = '#EXTM3U'
 const EXTINF = '#EXTINF:'

--- a/packages/vinyl-hls-parser/test/unit/parse/parseMediaPlaylist.test.ts
+++ b/packages/vinyl-hls-parser/test/unit/parse/parseMediaPlaylist.test.ts
@@ -727,4 +727,22 @@ describe('substituteVariables', () => {
     it('returns string unchanged when no variables', () => {
         expect(substitute('no-vars', {}, HLS_VARIABLE_PATTERN)).toBe('no-vars')
     })
+
+    it('does not scan a variable name across a token boundary', () => {
+        // The name class excludes '{', so a malformed prefix cannot swallow a
+        // following valid reference; only the inner '{$foo}' is substituted.
+        expect(
+            substitute('{$|{$foo}', { foo: 'X' }, HLS_VARIABLE_PATTERN)
+        ).toBe('{$|X')
+    })
+
+    it('stays linear on adversarial input (ReDoS guard)', () => {
+        // Repeated '{$|' forms no complete '{$name}' reference, so the input is
+        // returned unchanged. With a '[^}]' name class this scanned across '{'
+        // boundaries and ran in polynomial time; '[^{}]' keeps it linear.
+        const input = '{$|'.repeat(100_000)
+        const start = Date.now()
+        expect(substitute(input, {}, HLS_VARIABLE_PATTERN)).toBe(input)
+        expect(Date.now() - start).toBeLessThan(1000)
+    })
 })

--- a/packages/vinyl-util/src/event/nextEventAsPromise.ts
+++ b/packages/vinyl-util/src/event/nextEventAsPromise.ts
@@ -8,27 +8,40 @@ import type { ReadonlyAbort } from '../util/async/Abort'
 import { promise } from '../util/async/promise'
 import { withTimeout } from '../util/async/timeout'
 import type { Maybe } from '../util/type'
+import { ErrorLevel } from '../error/ReportableError'
+import { ErrorOrigin } from '../error/ErrorOrigin'
 
 export interface NextEventAsPromiseOptions<EventMap, K extends keyof EventMap> {
     /**
      * (Optional) If provided, will only resolve if the event passes this predicate.
      */
-    filter?: ((event: EventMap[K]) => boolean) | undefined | null
+    readonly filter?: ((event: EventMap[K]) => boolean) | undefined | null
 
     /**
      * (Optional) If provided, will reject the promise if the signal is aborted.
      */
-    abort?: Maybe<ReadonlyAbort>
+    readonly abort?: Maybe<ReadonlyAbort>
 
     /**
      * If provided, the promise will reject after this duration, in seconds, if not resolved.
      */
-    timeout?: number
+    readonly timeout?: number
 
     /**
      * The timeout message. If not provided will use `DEFAULT_TIMEOUT_MESSAGE`.
      */
-    timeoutMessage?: string
+    readonly timeoutMessage?: string
+
+    /**
+     * The error origin if the next event times out.
+     * Default: `ErrorOrigin.INTERNAL`
+     */
+    readonly timeoutOrigin?: string
+
+    /**
+     * The error level on a timeout.
+     */
+    readonly timeoutLevel?: ErrorLevel
 }
 
 /**
@@ -52,7 +65,12 @@ export function nextEventAsPromise<EventMap, K extends keyof EventMap>(
             })
         }, options?.abort),
         options?.timeout,
-        options?.timeoutMessage ??
-            `Event '${String(type)}' was not received within {time}s`
+        {
+            message:
+                options?.timeoutMessage ??
+                `Event '${String(type)}' was not received within {time}s`,
+            origin: options?.timeoutOrigin ?? ErrorOrigin.INTERNAL,
+            level: options?.timeoutLevel ?? ErrorLevel.FATAL,
+        }
     )
 }

--- a/packages/vinyl-util/src/util/async/timeout.ts
+++ b/packages/vinyl-util/src/util/async/timeout.ts
@@ -14,32 +14,65 @@ import { ErrorLevel } from '../../error/ReportableError'
 export const DEFAULT_TIMEOUT_MESSAGE = 'Timed out after {time}s'
 
 /**
+ * Options for {@link withTimeout}.
+ */
+export interface WithTimeoutOptions {
+    /**
+     * The message to set in the {@link TimeoutError}. Uses `{time}` token.
+     * (default: {@link DEFAULT_TIMEOUT_MESSAGE})
+     */
+    readonly message?: string | undefined
+
+    /**
+     * The error origin. (default: `ErrorOrigin.INTERNAL`)
+     */
+    readonly origin?: string | undefined
+
+    /**
+     * The error level. (default: `ErrorLevel.FATAL`)
+     */
+    readonly level?: ErrorLevel | undefined
+}
+
+/**
  * Races a promise with a timeout, rejecting with a {@link TimeoutError} if the timeout is
  * reached before the provided promise.
  *
  * @param promise The promise to race against a timeout.
  * @param time The number of seconds to wait. If undefined, the promise is returned without
  * wrapping.
- * @param message The message to set in the {@link TimeoutError}. Uses `{time}` token.
- * @param origin The error origin. (default: `ErrorOrigin.INTERNAL`)
- * @param level The error level (default: `ErrorLevel.FATAL`)
+ * @param options Timeout error options (message, origin, level).
  */
 export function withTimeout<T>(
     promise: PromiseLike<T>,
     time?: number,
-    message = DEFAULT_TIMEOUT_MESSAGE,
-    origin: string = ErrorOrigin.INTERNAL,
-    level: ErrorLevel = ErrorLevel.FATAL
+    options: WithTimeoutOptions = {}
 ): Promise<T> {
+    const {
+        message = DEFAULT_TIMEOUT_MESSAGE,
+        origin = ErrorOrigin.INTERNAL,
+        level = ErrorLevel.FATAL,
+    } = options
     if (time === undefined) return Promise.resolve(promise)
     const abort = new Abort()
     return Promise.race([
         promise,
-        timeout(time, abort, message, origin, level),
+        timeout(time, { abort, message, origin, level }),
     ]).then(() => {
         abort.abort()
         return promise
     })
+}
+
+/**
+ * Options for {@link timeout}.
+ */
+export interface TimeoutOptions extends WithTimeoutOptions {
+    /**
+     * If provided, when aborted (regardless of reason) will resolve the
+     * returned promise rather than rejecting.
+     */
+    readonly abort?: ReadonlyAbort | undefined
 }
 
 /**
@@ -48,19 +81,18 @@ export function withTimeout<T>(
  * This is the inverse of {@link sleep}
  *
  * @param time The number of seconds to wait.
- * @param abort If provided, when aborted (regardless of reason) will resolve the returned
- * promise.
- * @param message The message to be used in the TimeoutError in case of timeout. Uses `{time}` token.
- * @param origin The error origin. (default: `ErrorOrigin.INTERNAL`)
- * @param level The error level (default: `ErrorLevel.FATAL`)
+ * @param options Timeout options (abort, message, origin, level).
  */
 export function timeout(
     time: number,
-    abort?: ReadonlyAbort,
-    message = 'Timed out after {time}s',
-    origin: string = ErrorOrigin.INTERNAL,
-    level: ErrorLevel = ErrorLevel.FATAL
+    options: TimeoutOptions = {}
 ): Promise<void> {
+    const {
+        abort,
+        message = DEFAULT_TIMEOUT_MESSAGE,
+        origin = ErrorOrigin.INTERNAL,
+        level = ErrorLevel.FATAL,
+    } = options
     return new Promise((resolve, reject) => {
         sleep(time, abort)
             .then(() => {

--- a/packages/vinyl-util/test/testUtil/util/event/createEventSpy.ts
+++ b/packages/vinyl-util/test/testUtil/util/event/createEventSpy.ts
@@ -59,14 +59,12 @@ export function createEventSpy<EventMap, K extends keyof EventMap>(
             timeout = 5,
             timeoutMessage = `event '{type}' has not been dispatched after {timeout}s.`
         ) {
-            return withTimeout(
-                nextCall,
-                timeout,
-                substitute(timeoutMessage, {
+            return withTimeout(nextCall, timeout, {
+                message: substitute(timeoutMessage, {
                     type,
                     timeout,
-                })
-            )
+                }),
+            })
         },
         dispose: unsub,
     })

--- a/packages/vinyl-util/test/unit/util/async/timeout.test.ts
+++ b/packages/vinyl-util/test/unit/util/async/timeout.test.ts
@@ -37,7 +37,7 @@ describe('withTimeout', () => {
 
     it('uses the provided message for the timeout error', async () => {
         const expectation = expectAsync(
-            withTimeout(sleep(20.0), 10, 'erred in {time}s')
+            withTimeout(sleep(20.0), 10, { message: 'erred in {time}s' })
         ).toBeRejectedWithError(TimeoutError, 'erred in 10s')
         await clock.tick(10, 10)
         await expectation
@@ -88,7 +88,7 @@ describe('timeout', () => {
 
     it('resolves if a provided abort signal is aborted', async () => {
         const abort = new Abort()
-        const promise = timeout(1000, abort)
+        const promise = timeout(1000, { abort })
         await clock.tick(500.0)
         abort.abort()
         await expectAsync(promise).toBeResolvedTo(void 0)

--- a/packages/vinyl/src/ad/AdControllerImpl.ts
+++ b/packages/vinyl/src/ad/AdControllerImpl.ts
@@ -10,6 +10,7 @@ import {
     lerp,
     logDebug,
     type Maybe,
+    noop,
     resolveValueProvider,
     roundToNearest,
     sleep,
@@ -366,6 +367,7 @@ export class AdControllerImpl
             .catch(() => undefined)
         resolveValueProvider(value?.ads)
             .then((ads) => {
+                if (this.disposed) return
                 if (this._currentAdBreak !== value) return
                 const adsList = ads?.slice() ?? []
                 this.pendingAds = adsList
@@ -420,15 +422,18 @@ export class AdControllerImpl
             index: this._currentAdIndex,
             totalAds: this._totalAds,
         })
-        void sleep(this.options.adLoadTimeout).then(() => {
-            if (this.adStats === stats && !stats.playing) {
-                this.failAd(
-                    new AdError(
-                        `Ad failed to start after ${this.options.adLoadTimeout} seconds`
+        sleep(this.options.adLoadTimeout)
+            .then(() => {
+                if (this.disposed) return
+                if (this.adStats === stats && !stats.playing) {
+                    this.failAd(
+                        new AdError(
+                            `Ad failed to start after ${this.options.adLoadTimeout} seconds`
+                        )
                     )
-                )
-            }
-        })
+                }
+            })
+            .catch(noop)
     }
 
     private completeAd(reason: AdChangeReason) {

--- a/packages/vinyl/src/ad/AdControllerImpl.ts
+++ b/packages/vinyl/src/ad/AdControllerImpl.ts
@@ -213,16 +213,21 @@ export class AdControllerImpl
     }
 
     /**
-     * Records a break as complete when it has played. Play-once breaks (and
-     * prerolls, which are one-shot per presentation) are suppressed permanently;
-     * replayable midrolls are only marked "spent" so they can re-arm on a
-     * seek-back. Postrolls are event-driven ({@link enterPostroll}) and need no
-     * suppression.
+     * Records a break as complete when it has played. Play-once breaks,
+     * prerolls and postrolls are one-shot per presentation (suppressed
+     * permanently); midrolls are only "spent" so they re-arm on a seek-back.
+     * Postrolls must be suppressed or a repeated content `ended` would replay
+     * them in a loop.
      */
     private markBreakComplete(adBreak: AdBreakInfo): void {
-        if (adBreak.once || adBreak.placement === 'preroll') {
+        if (
+            adBreak.once ||
+            adBreak.placement === 'preroll' ||
+            adBreak.placement === 'postroll'
+        ) {
             this.completeAdBreakIds.add(adBreak.id)
-        } else if (adBreak.placement === 'midroll') {
+        } else {
+            // midroll
             this.spentBreakIds.add(adBreak.id)
         }
     }

--- a/packages/vinyl/src/drm/DrmControllerImpl.ts
+++ b/packages/vinyl/src/drm/DrmControllerImpl.ts
@@ -170,6 +170,7 @@ export class DrmControllerImpl
                     params.keySystem,
                     [params.config]
                 )
+                this.abortIfDisposed()
                 logVerbose(
                     this,
                     'requestMediaKeySystemAccess supported',
@@ -181,7 +182,12 @@ export class DrmControllerImpl
                         params.config.persistentState === 'required',
                 }
             } catch (_) {
-                logVerbose(this, 'requestMediaKeySystemAccess rejected', params)
+                if (!this.disposed)
+                    logVerbose(
+                        this,
+                        'requestMediaKeySystemAccess rejected',
+                        params
+                    )
                 return { supported: false, persistentState: false }
             }
         },
@@ -236,6 +242,7 @@ export class DrmControllerImpl
                 this.abortIfDisposed()
                 this.mediaKeys = mediaKeys
                 await mediaKeys.setOnElement(this.deps.media)
+                this.abortIfDisposed()
                 logDebug(this, `set media keys on element`)
                 this.dispatch('mediaKeysSet', {
                     keySystem: mediaKeys.keySystem,
@@ -293,6 +300,7 @@ export class DrmControllerImpl
             })
             newSession.on('closed', () => this.closeSession(newSession))
             abort?.onAborted(() => {
+                if (this.disposed) return
                 logDebug(this, 'abort session')
                 this.closeSession(newSession)
             })
@@ -372,11 +380,13 @@ export class DrmControllerImpl
                         keySystem,
                         [config]
                     )
-                logDebug(
-                    this,
-                    `created media key system access for keySystem: ${access.keySystem}}`,
-                    config
-                )
+                if (!this.disposed) {
+                    logDebug(
+                        this,
+                        `created media key system access for keySystem: ${access.keySystem}}`,
+                        config
+                    )
+                }
                 return access
             } catch (_) {
                 // ignore
@@ -491,6 +501,7 @@ export class DrmControllerImpl
             defaultInitDataTransformer(mediaKeys.keySystem, certBytes)
         initData = transform(bufferToByteArray(initData), initDataType, drmInfo)
 
+        this.abortIfDisposed()
         logDebug(this, 'createSession', drmInfo.mimeType, initDataType)
         const session = mediaKeys.createSession(
             drmInfo.mimeType,
@@ -535,6 +546,7 @@ export class DrmControllerImpl
         const licenseServerOptions =
             clone(await resolveValueProvider(licenseServerOptionsProvider)) ??
             {}
+        this.abortIfDisposed()
 
         let challenge: BodyInit = event.message
         if (isPlayReady(keySystem)) {
@@ -574,6 +586,10 @@ export class DrmControllerImpl
     }
 
     private closeSession(session: CommonMediaKeySession) {
+        // Sessions are closed synchronously during dispose() (before the
+        // disposer flips `disposed`), but a session's own async 'closed'/'error'
+        // can arrive after teardown.
+        if (this.disposed) return
         logDebug(this, 'closeSession')
         session.dispose()
         remove(this.sessions, session)

--- a/packages/vinyl/src/drm/DrmControllerImpl.ts
+++ b/packages/vinyl/src/drm/DrmControllerImpl.ts
@@ -516,7 +516,7 @@ export class DrmControllerImpl
                     event: event,
                 }),
                 LICENSE_TIMEOUT,
-                LICENSE_TIMEOUT_MESSAGE
+                { message: LICENSE_TIMEOUT_MESSAGE }
             ).catch(this.handleError)
         })
         session.on('error', (event) => {

--- a/packages/vinyl/src/playback/PlaybackControllerImpl.ts
+++ b/packages/vinyl/src/playback/PlaybackControllerImpl.ts
@@ -564,9 +564,11 @@ export class PlaybackControllerImpl
                     await withTimeout(
                         this.media.play(),
                         this.options.playTimeout,
-                        'play() timed out after {time}s',
-                        ErrorOrigin.INTERNAL,
-                        ErrorLevel.SILENT
+                        {
+                            message: 'play() timed out after {time}s',
+                            origin: ErrorOrigin.INTERNAL,
+                            level: ErrorLevel.SILENT,
+                        }
                     )
                 })(),
                 playAbort
@@ -612,16 +614,13 @@ export class PlaybackControllerImpl
         const nextEvent = <K extends keyof PlaybackControllerEventMap>(
             type: K
         ): Promise<PlaybackControllerEventMap[K]> => {
-            return withAbort(
-                withTimeout(
-                    nextEventAsPromise(this, type),
-                    this.options.seekTimeout,
-                    `seek timed out on ${type} event after {time}s`,
-                    ErrorOrigin.INTERNAL,
-                    ErrorLevel.WARN
-                ),
-                this.disposeAbort
-            )
+            return nextEventAsPromise(this, type, {
+                timeout: this.options.seekTimeout,
+                timeoutMessage: `seek timed out on ${type} event after {time}s`,
+                timeoutOrigin: ErrorOrigin.INTERNAL,
+                timeoutLevel: ErrorLevel.WARN,
+                abort: this.disposeAbort,
+            })
         }
 
         // Cannot seek until there are seekable ranges.

--- a/packages/vinyl/src/streaming/buffering/MediaSourceController.ts
+++ b/packages/vinyl/src/streaming/buffering/MediaSourceController.ts
@@ -224,6 +224,10 @@ export class MediaSourceControllerImpl
         if (!this.active) return
         this.activateDisposer!.dispose()
         this.activateDisposer = null
+        // Invalidate any in-flight refreshDuration so its continuation returns
+        // at the token check rather than setting duration (and logging) after
+        // deactivation.
+        ++this.durationToken
         try {
             URL.revokeObjectURL(this.objectUrl!)
         } catch (error) {

--- a/packages/vinyl/src/track/TrackController.ts
+++ b/packages/vinyl/src/track/TrackController.ts
@@ -612,6 +612,9 @@ export class TrackControllerImpl<TrackLoadOptionsType extends TrackLoadOptions>
                                 )
                             })
                             .catch((error) => {
+                                // The provider (a HEAD probe) isn't canceled on
+                                // dispose; don't log after teardown.
+                                if (this.disposed) return
                                 logWarn(
                                     this,
                                     'failed to resolve ad track load options for preload',
@@ -621,6 +624,9 @@ export class TrackControllerImpl<TrackLoadOptionsType extends TrackLoadOptions>
                     }
                 })
                 .catch((error) => {
+                    // The ads provider may fetch and isn't canceled on dispose;
+                    // don't log after teardown.
+                    if (this.disposed) return
                     logWarn(this, 'failed to resolve ads for preload', error)
                 })
         }

--- a/packages/vinyl/src/track/TrackController.ts
+++ b/packages/vinyl/src/track/TrackController.ts
@@ -403,32 +403,38 @@ export class TrackControllerImpl<TrackLoadOptionsType extends TrackLoadOptions>
     private onTrackEnded = () => {
         const { adController } = this.deps
 
+        // `ended` fires for ad tracks too (they share the media element); an
+        // ad's end is the AdController's concern, not the content ending.
+        // Detect an ad track by identity rather than adController.currentAd,
+        // which its own `ended` handler may have already cleared (race).
+        const onAdTrack =
+            this._adParent != null &&
+            this._current != null &&
+            this._current.uri !== this._adParent.uri
+        if (onAdTrack) return
+
         const interrupted = this.getQueueInterrupted()
-        const ad = adController.currentAd
-
-        if (!ad) {
-            adController.enterPostroll()
-            if (adController.currentAdBreak) {
-                // There is a pending postroll, do not advance the queue,
-                // a new adEntered event will fire.
-                return
-            }
-
-            // Adds a frame delay to allow applications an opportunity to respond to 'ended' events before the
-            // queue is advanced.
-            setTimeout(() => {
-                if (interrupted()) return
-                // The content ended with no postroll: the track is done.
-                logDebug(this, 'trackEnded')
-                this.dispatch('trackEnded', {})
-                if (this.hasNext()) {
-                    this.next()
-                } else {
-                    logInfo(this, 'queueEnded')
-                    this.dispatch('queueEnded', {})
-                }
-            })
+        adController.enterPostroll()
+        if (adController.currentAdBreak) {
+            // There is a pending postroll, do not advance the queue,
+            // a new adEntered event will fire.
+            return
         }
+
+        // Adds a frame delay to allow applications an opportunity to respond to 'ended' events before the
+        // queue is advanced.
+        setTimeout(() => {
+            if (interrupted()) return
+            // The content ended with no postroll: the track is done.
+            logDebug(this, 'trackEnded')
+            this.dispatch('trackEnded', {})
+            if (this.hasNext()) {
+                this.next()
+            } else {
+                logInfo(this, 'queueEnded')
+                this.dispatch('queueEnded', {})
+            }
+        })
     }
 
     /**

--- a/packages/vinyl/src/util/media/mediaSource.ts
+++ b/packages/vinyl/src/util/media/mediaSource.ts
@@ -121,6 +121,6 @@ export function nextMediaSourceEnded(
             onMediaSourceEnded(mediaSource, resolve, { once: true })
         }),
         timeout,
-        timeoutMessage
+        { message: timeoutMessage }
     )
 }

--- a/packages/vinyl/test/integ/patch/media/patches/createUnreliablePlaybackEventsPatch.test.ts
+++ b/packages/vinyl/test/integ/patch/media/patches/createUnreliablePlaybackEventsPatch.test.ts
@@ -102,7 +102,7 @@ describe('unreliablePlaybackEventsPatch integ', () => {
 
         // Some browsers (iOS) do not support seeking before a play has happened in a secure
         // context. seekTo will cause the seek to be pending until the first play.
-        await withTimeout(media.play(), 10, 'play timed out')
+        await withTimeout(media.play(), 10, { message: 'play timed out' })
 
         media.currentTime = 15
         let canReproduce: boolean

--- a/packages/vinyl/test/integ/playback/reset.test.ts
+++ b/packages/vinyl/test/integ/playback/reset.test.ts
@@ -16,14 +16,12 @@ import type {
     RequestOptions,
 } from '@amazon/vinyl-util'
 import {
-    createRequester,
     networkState,
     noop,
     type Requester,
     RequestError,
     requesterWithRetryRef,
     RequestFailureType,
-    RetryStrategy,
     sleep,
 } from '@amazon/vinyl-util'
 import { createVinylSuite, vinylTestAssets } from '@amazon/vinyl/vinylTestUtil'
@@ -43,40 +41,6 @@ import { normalizeHeadersInit } from '@amazon/vinyl-util'
 const playbackTime = 5
 
 describe('reset integ', () => {
-    overrideGlobalInit(requesterWithRetryRef, () => {
-        const requester = createRequester({
-            retryOptions: RetryStrategy.ONE_RETRY,
-        })
-        const originalRequest = requester.request.bind(requester)
-        spyOn(requester, 'request').and.callFake(
-            async (
-                input: RequestInfo | Readonly<URL>,
-                init?: Maybe<RequestInitOptions>,
-                requestOptions?: Maybe<RequestOptions>
-            ) => {
-                if (!requestGate(input, init, requestOptions)) {
-                    await sleep(0.1)
-                    throw new RequestError(null, {
-                        ok: false,
-                        type: RequestFailureType.INTERNAL,
-                        willRetry: false,
-                        retryAfter: null,
-                        reason: null,
-                        timestamp: Date.now(),
-                        requestInfo: {
-                            ...emptyRequestInfo,
-                            init: init ?? emptyRequestInfo.init,
-                            input,
-                        },
-                    })
-                }
-                return originalRequest(input, init, requestOptions)
-            }
-        )
-
-        return requester
-    })
-
     let mockNetworkState: MockNetworkState
     const mockNetworkStateRef = overrideGlobalInit(
         networkState,
@@ -111,6 +75,40 @@ describe('reset integ', () => {
     let failNext: boolean
 
     beforeEach(() => {
+        // Spy on the requester the suite actually configures (createVinylSuite
+        // registers an earlier `beforeEach` that overrides requesterWithRetryRef
+        // for BrowserStack retries). Spying on the initialized instance here —
+        // rather than racing another `set()` override, which the suite's would
+        // clobber — guarantees this failure-injection gate is what the player
+        // uses while preserving the suite's requester configuration.
+        const requester = requesterWithRetryRef.value
+        const originalRequest = requester.request.bind(requester)
+        spyOn(requester, 'request').and.callFake(
+            async (
+                input: RequestInfo | Readonly<URL>,
+                init?: Maybe<RequestInitOptions>,
+                requestOptions?: Maybe<RequestOptions>
+            ) => {
+                if (!requestGate(input, init, requestOptions)) {
+                    await sleep(0.1)
+                    throw new RequestError(null, {
+                        ok: false,
+                        type: RequestFailureType.INTERNAL,
+                        willRetry: false,
+                        retryAfter: null,
+                        reason: null,
+                        timestamp: Date.now(),
+                        requestInfo: {
+                            ...emptyRequestInfo,
+                            init: init ?? emptyRequestInfo.init,
+                            input,
+                        },
+                    })
+                }
+                return originalRequest(input, init, requestOptions)
+            }
+        )
+
         mockNetworkState = mockNetworkStateRef.value
         mockNetworkState.onLine = true
         failNext = false

--- a/packages/vinyl/test/integ/track/hls/adInterstitials.test.ts
+++ b/packages/vinyl/test/integ/track/hls/adInterstitials.test.ts
@@ -645,6 +645,39 @@ describe('hls ad interstitials integ', () => {
         ).toBeTrue()
     })
 
+    // ─── Natural playback ordering ───────────────────────────────────────
+    // Playing from the start (no seeking) enters breaks in timeline order.
+    it('activates a midroll during natural forward playback (no seek)', async () => {
+        const player = suite.player
+        // Midroll early enough to reach by playing from the start.
+        player.load({
+            type: 'hls',
+            uri: 'integ-natural-mid',
+            manifestProvider: injectingManifestProvider(CONTENT_ASSET, [
+                {
+                    id: 'mid',
+                    startTime: 3,
+                    duration: MIDROLL_DURATION,
+                    assetUri: AD_ASSET,
+                },
+            ]),
+        })
+        await poll(() => (player.currentTrackAds?.adBreaks.length ?? 0) > 0, {
+            timeout: 15,
+        })
+        // Play from the start and let the playhead cross the break naturally —
+        // no seek. The midroll must activate on the forward crossing.
+        await player.play().catch(noop)
+        expect(
+            await poll(() => player.currentAdBreak?.id === 'mid', {
+                timeout: 40,
+            })
+        )
+            .withContext('midroll activated on natural crossing')
+            .toBeTrue()
+        expect(player.currentAdBreak?.placement).toBe('midroll')
+    })
+
     it('plays multiple ads in a break sequentially (X-ASSET-LIST)', async () => {
         const player = suite.player
         player.load({
@@ -783,6 +816,77 @@ describe('hls ad interstitials integ', () => {
         expect(await poll(() => player.paused || player.ended, { timeout: 20 }))
             .withContext('player.paused || player.ended')
             .toBeTrue()
+    })
+
+    it('does not replay a postroll after it finishes naturally', async () => {
+        const player = suite.player
+        // A postroll that is never suppressed re-enters on each content
+        // `ended`, looping forever. Record every entry to catch a replay.
+        const postrollEntries: string[] = []
+        const sub = player.on('currentAdBreakChange', (e) => {
+            if (e.current?.placement === 'postroll') {
+                postrollEntries.push(e.current.id)
+            }
+        })
+        try {
+            player.load({
+                type: 'hls',
+                uri: 'integ-postroll-replay',
+                manifestProvider: injectingManifestProvider(CONTENT_ASSET, [
+                    {
+                        id: 'postroll-1',
+                        startTime: 0,
+                        duration: 4,
+                        // Short ad so the break ends quickly on its own.
+                        assetList: [{ uri: AD_ASSET, duration: 3 }],
+                        cue: 'POST',
+                    },
+                ]),
+            })
+            await poll(
+                () => (player.currentTrackAds?.adBreaks.length ?? 0) > 0,
+                { timeout: 15 }
+            )
+            await player.play().catch(noop)
+            // Drive content to its end so the postroll triggers on `ended`.
+            const contentDuration = player.duration
+            await player
+                .seekTo(Math.max(0, contentDuration - 1.5), 1)
+                .catch(() => undefined)
+            // The postroll takes over and plays.
+            expect(await poll(() => player.currentAd != null, { timeout: 40 }))
+                .withContext('postroll ad started')
+                .toBeTrue()
+            expect(player.currentAdBreak?.placement).toBe('postroll')
+            // Let the postroll finish on its own, rather than skipping it.
+            expect(await poll(() => player.currentAd == null, { timeout: 40 }))
+                .withContext('postroll ad finished')
+                .toBeTrue()
+            // Content resumes on the content track after the break.
+            expect(
+                await poll(
+                    () => player.currentTrack?.uri === 'integ-postroll-replay',
+                    { timeout: 20 }
+                )
+            )
+                .withContext('content resumed after postroll')
+                .toBeTrue()
+
+            // Re-drive content to its end to fire `ended` again — the event
+            // that re-invokes enterPostroll. It must not re-enter the postroll.
+            await player
+                .seekTo(Math.max(0, player.duration - 1.5), 1)
+                .catch(() => undefined)
+            await player.play().catch(noop)
+            const replayed = await poll(() => postrollEntries.length > 1, {
+                timeout: 20,
+            })
+            expect(replayed).withContext('postroll replayed').toBeFalse()
+            expect(player.currentAdBreak).toBeNull()
+            expect(postrollEntries).toEqual(['postroll-1'])
+        } finally {
+            sub()
+        }
     })
 
     it('disposes the ad track when new content is loaded mid-ad', async () => {
@@ -1106,5 +1210,64 @@ describe('hls ad interstitials integ (art19 real stream)', () => {
         expect(await poll(() => player.currentAd == null, { timeout: 30 }))
             .withContext('player.currentAd == null')
             .toBeTrue()
+    })
+
+    // Regression (real stream): the preroll ad's own `ended` was misread as
+    // content ending, so the postroll played right after the preroll — before
+    // content. After the preroll ends, content must resume, not the postroll.
+    it('resumes content, not the postroll, after the preroll ends (natural)', async () => {
+        const player = suite.player
+        const enteredPlacements: string[] = []
+        const sub = player.on('currentAdBreakChange', (e) => {
+            if (e.current) enteredPlacements.push(e.current.placement)
+        })
+        try {
+            player.load({ type: 'hls', uri: STREAM })
+            if (
+                !(await poll(
+                    () => (player.currentTrackAds?.adBreaks.length ?? 0) > 0,
+                    { timeout: 20 }
+                ))
+            ) {
+                pending('art19 stream unreachable')
+                return
+            }
+            const placements = player.currentTrackAds!.adBreaks.map(
+                (b) => b.placement
+            )
+            expect(placements).toContain('preroll')
+            expect(placements).toContain('postroll')
+
+            await player.play().catch(() => undefined)
+            // The preroll activates at time 0 and its ad advances.
+            if (
+                !(await poll(() => player.currentAd != null, { timeout: 30 }))
+            ) {
+                pending('art19 ad did not start (network/CDN)')
+                return
+            }
+            if (!(await poll(() => player.currentTime > 0, { timeout: 20 }))) {
+                pending('art19 ad activated but did not advance (network/CDN)')
+                return
+            }
+            expect(player.currentAdBreak?.placement)
+                .withContext('preroll first')
+                .toBe('preroll')
+            // Let the preroll play to its own natural end (no seeking — the bug
+            // needs the ad's real `ended`). Watch long enough to cover its
+            // playout: the postroll must not activate right after the preroll.
+            const wrongPostroll = await poll(
+                () => enteredPlacements.includes('postroll'),
+                { timeout: 45 }
+            )
+            expect(wrongPostroll)
+                .withContext('postroll must not play right after the preroll')
+                .toBeFalse()
+            expect(enteredPlacements)
+                .withContext('only the preroll has played')
+                .toEqual(['preroll'])
+        } finally {
+            sub()
+        }
     })
 })

--- a/packages/vinyl/test/unit/ad/AdControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/ad/AdControllerImpl.test.ts
@@ -1143,6 +1143,48 @@ describe('AdControllerImpl', () => {
         })
     })
 
+    describe('disposal during pending async work', () => {
+        it('ignores a break ad list that resolves after disposal', async () => {
+            const c = createController()
+            let resolveAds: (ads: readonly AdInfo[]) => void = () => {}
+            c.setAds(
+                trackAds(
+                    makeBreak({
+                        startTime: 10,
+                        ads: () =>
+                            new Promise<readonly AdInfo[]>((resolve) => {
+                                resolveAds = resolve
+                            }),
+                    })
+                )
+            )
+            updateTime(10)
+            c.dispose()
+            resolveAds([defaultAd])
+            await flush()
+            expect(c.currentAd).toBeNull()
+        })
+
+        it('does not fail an ad after disposal when the load timeout elapses', async () => {
+            // A small non-zero timeout so the timer is a real setTimeout that
+            // fires after we dispose (sleep(0) would resolve on a microtask,
+            // before dispose).
+            const c = new AdControllerImpl(
+                { playbackController },
+                { adLoadTimeout: 0.001 }
+            )
+            const errors: unknown[] = []
+            c.on('adError', (e) => errors.push(e.error))
+            c.setAds(trackAds(makeBreak({ startTime: 0, duration: 10 })))
+            updateTime(1)
+            await flush()
+            // Dispose before the load-timeout timer fires.
+            c.dispose()
+            await new Promise((resolve) => setTimeout(resolve, 5))
+            expect(errors).toEqual([])
+        })
+    })
+
     describe('dispose', () => {
         it('stops responding to time updates', async () => {
             const c = createController()

--- a/packages/vinyl/test/unit/ad/AdControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/ad/AdControllerImpl.test.ts
@@ -873,8 +873,12 @@ describe('AdControllerImpl', () => {
             expect(c.currentAdBreak).toBeNull()
         })
 
-        it('does not suppress a postroll, letting enterPostroll replay it', async () => {
+        it('suppresses a completed postroll so enterPostroll does not replay it', async () => {
             const c = createController()
+            const entered: string[] = []
+            c.on('currentAdBreakChange', (e) => {
+                if (e.current) entered.push(e.current.id)
+            })
             c.setAds(
                 trackAds(
                     makeBreak({
@@ -885,14 +889,24 @@ describe('AdControllerImpl', () => {
                     })
                 )
             )
+            // Content ends: the postroll activates and its single ad plays out.
             c.enterPostroll()
             await flush()
             expect(c.currentAd?.id).toBe('a1')
-            c.skipAd() // completes postroll → no permanent/transient suppression
+            playbackController.dispatch('ended', {
+                previous: false,
+                current: true,
+            })
             expect(c.currentAdBreak).toBeNull()
+            // A re-fired content `ended` calls enterPostroll again; the
+            // already-played postroll must not replay.
             c.enterPostroll()
             await flush()
-            expect(c.currentAdBreak?.id).toBe('post')
+            expect(c.currentAdBreak)
+                .withContext('postroll must not replay')
+                .toBeNull()
+            expect(c.currentAd).toBeNull()
+            expect(entered).toEqual(['post'])
         })
     })
 

--- a/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
@@ -444,6 +444,21 @@ describe('DrmControllerImpl', () => {
                 ).toEqual([1, 1, 1, 1, 1, 1]) // Expect all sessions to have been disposed
                 expect(drmController.activeSessions).toEqual(0)
             })
+
+            it('ignores a session that closes or aborts after disposal', async () => {
+                const abort = new Abort()
+                drmController.setBufferingDrmInfo(drmInfo, abort)
+                await emitEncrypted(new Uint8Array([1]))
+                const session = mediaKeys.createSession.calls.mostRecent()
+                    .returnValue as MockCommonMediaKeySession
+                drmController.dispose()
+                session.dispose.calls.reset()
+                // A late 'closed' and a late abort must be ignored after
+                // teardown (no re-close, no post-dispose log).
+                session.dispatch('closed', { reason: 'closed-by-application' })
+                abort.abort()
+                expect(session.dispose).not.toHaveBeenCalled()
+            })
         })
     })
 
@@ -1349,6 +1364,26 @@ describe('DrmControllerImpl', () => {
                 DrmKeySystem.WIDEVINE,
                 DrmKeySystem.PLAY_READY,
             ])
+        })
+
+        it('does not log a support result after disposal', async () => {
+            // A memoized probe still in flight when the controller is disposed
+            // must resolve inertly without logging its result post-teardown.
+            let resolveAccess: (
+                a: MockCommonMediaKeySystemAccess
+            ) => void = () => {}
+            commonEme.requestMediaKeySystemAccess.and.returnValue(
+                new Promise<MockCommonMediaKeySystemAccess>((resolve) => {
+                    resolveAccess = resolve
+                })
+            )
+            const supported = drmController.isSupported(drmInfo)
+            drmController.dispose()
+            resolveAccess(access)
+            await expectAsync(supported).toBeResolvedTo({
+                supported: false,
+                persistentState: false,
+            })
         })
     })
 

--- a/packages/vinyl/test/unit/track/TrackController.test.ts
+++ b/packages/vinyl/test/unit/track/TrackController.test.ts
@@ -1404,6 +1404,70 @@ describe('TrackControllerImpl', () => {
 
             expect(tc.isTrackCached('https://ads/late.m3u8')).toBeFalse()
         })
+
+        it('does not throw when ad options reject after disposal', async () => {
+            // The HEAD-probe provider isn't cancelled on dispose; a rejection
+            // after teardown must hit the guard, not log.
+            let rejectOptions: (error: Error) => void = () => {}
+            const tc = new TrackControllerImpl<TrackLoadOptions>({
+                ...deps,
+                adTrackLoadOptionsProvider: () =>
+                    new Promise<TrackLoadOptions>((_resolve, reject) => {
+                        rejectOptions = reject
+                    }),
+            })
+            const [main] = createLoadOptionsList(1)
+            tc.load(main)
+            const track = tc.currentTrack as MockTrack
+            const ads = trackAdsWith(main.uri, 'https://ads/late.m3u8')
+            track.ads = ads
+            track.dispatch('adsChange', { previous: null, current: ads })
+            await flushAds()
+
+            tc.dispose()
+            rejectOptions(new Error('boom'))
+            await flushAds()
+
+            expect(tc.disposed).toBeTrue()
+            expect(tc.isTrackCached('https://ads/late.m3u8')).toBeFalse()
+        })
+
+        it("does not throw when a break's ad list rejects after disposal", async () => {
+            let rejectAds: (error: Error) => void = () => {}
+            const tc = new TrackControllerImpl<TrackLoadOptions>(deps)
+            const [main] = createLoadOptionsList(1)
+            tc.load(main)
+            const track = tc.currentTrack as MockTrack
+            const ads = {
+                trackUri: main.uri,
+                adBreaks: [
+                    {
+                        id: 'b1',
+                        startTime: 5,
+                        duration: 10,
+                        placement: 'midroll' as const,
+                        restrict: {},
+                        once: false,
+                        resumeOffset: null,
+                        playoutLimit: null,
+                        skipControl: () => null,
+                        ads: () =>
+                            new Promise<readonly []>((_resolve, reject) => {
+                                rejectAds = reject
+                            }),
+                    },
+                ],
+            }
+            track.ads = ads
+            track.dispatch('adsChange', { previous: null, current: ads })
+            await flushAds()
+
+            tc.dispose()
+            rejectAds(new Error('ad list down'))
+            await flushAds()
+
+            expect(tc.disposed).toBeTrue()
+        })
     })
 
     describe('ad track lifecycle', () => {

--- a/packages/vinyl/test/unit/track/TrackController.test.ts
+++ b/packages/vinyl/test/unit/track/TrackController.test.ts
@@ -1675,6 +1675,28 @@ describe('TrackControllerImpl', () => {
             expect(trackController.currentTrack?.uri).toBe(main.uri)
         })
 
+        it('ignores an ended event fired while an ad track is playing', async () => {
+            trackController.load(...createLoadOptionsList(1))
+            deps.adController.currentAd = ad
+            deps.adController.dispatch('adEntered', {
+                ad,
+                index: 0,
+                totalAds: 1,
+            })
+            await flushAds()
+            // The ad track is now current over its parent content track.
+            expect(trackController.currentTrack?.uri).toBe('https://ads/x.m3u8')
+            const trackEnded = createEventSpy(trackController, 'trackEnded')
+            const queueEnded = createEventSpy(trackController, 'queueEnded')
+            // `ended` fires for the ad track too; the ad's end is the
+            // AdController's concern, so the content must not be advanced.
+            deps.playbackController.dispatch('ended', {})
+            await clock.tick()
+            expect(deps.adController.enterPostroll).not.toHaveBeenCalled()
+            expect(trackEnded).not.toHaveBeenCalled()
+            expect(queueEnded).not.toHaveBeenCalled()
+        })
+
         it('fails the ad when the current track errors', () => {
             trackController.load(...createLoadOptionsList(1))
             const track = trackController.currentTrack as MockTrack


### PR DESCRIPTION
fix(ad): play breaks in timeline order and stop postroll replay

On the art19 interstitials VOD, natural playback ran preroll → postroll →
midrolls before content, then looped the postroll.

1. TrackController.onTrackEnded treated an ad track's `ended` as the
   content ending (the guard on adController.currentAd loses a
   listener-order race), mis-firing enterPostroll(). Detect an ad track by
   identity instead.
2. AdControllerImpl.markBreakComplete never suppressed postrolls, so a
   repeated content `ended` re-entered them; suppress postrolls as
   one-shot per presentation.

Adds real-stream ordering, postroll no-replay, and natural midroll integ
tests; corrects the unit test that encoded the buggy replay.