### PR TITLE
Fix/video drm seek

### DIFF
--- a/packages/vinyl-website/src/components/CaptionsControl.tsx
+++ b/packages/vinyl-website/src/components/CaptionsControl.tsx
@@ -29,15 +29,12 @@ export function CaptionsControl() {
         captionsEnabled$.value = false
     }
 
+    // Always open the dropdown (which offers "Off" plus every track), even for
+    // a single caption option, so the control behaves consistently regardless
+    // of track count and always shows the current selection.
     const onCcClick = () => {
-        const tracks = textTracks$.value
-        const active = activeTextTrack$.value
-        if (tracks.length > 1) {
+        if (textTracks$.value.length > 0) {
             menuOpen$.value = !menuOpen$.value
-        } else if (active) {
-            deactivate()
-        } else if (tracks.length === 1) {
-            activateTrack(tracks[0])
         }
     }
 

--- a/packages/vinyl-website/src/components/PlayerPage.tsx
+++ b/packages/vinyl-website/src/components/PlayerPage.tsx
@@ -9,35 +9,33 @@ import { data } from '@amazon/vinyl-observable'
 import { Icon } from './icons'
 import { toastError } from './toast'
 
-const ASSETS_HOST = 'https://assets.dev.vinyl.music.amazon.dev'
-
 const demoTracks: Track[] = [
     {
         title: 'Audio Only (DASH)',
         type: 'dash',
         contentType: 'audio',
-        url: `${ASSETS_HOST}/dash/world___bpm85/manifest.mpd`,
+        url: `https://assets.dev.vinyl.music.amazon.dev/dash/world___bpm85/manifest.mpd`,
         description: 'DASH audio-only stream',
     },
     {
         title: 'Video + Audio (DASH)',
         type: 'dash',
         contentType: 'video',
-        url: `${ASSETS_HOST}/dash/live_static_video_audio_60s_4s_segmentTemplate/manifest.mpd`,
+        url: `https://assets.dev.vinyl.music.amazon.dev/dash/live_static_video_audio_60s_4s_segmentTemplate/manifest.mpd`,
         description: '60s DASH segment template, video and audio',
     },
     {
         title: 'Video + Audio fMP4 (HLS)',
         type: 'hls',
         contentType: 'video',
-        url: `${ASSETS_HOST}/hls/live_static_video_audio_60s_4s/main.m3u8`,
+        url: `https://assets.dev.vinyl.music.amazon.dev/hls/live_static_video_audio_60s_4s/main.m3u8`,
         description: '60s HLS video and audio stream',
     },
     {
         title: 'Video + Audio MPEGTS (HLS)',
         type: 'hls',
         contentType: 'video',
-        url: `${ASSETS_HOST}/hls/live_static_video_audio_60s_4s_mpegts/main.m3u8`,
+        url: `https://assets.dev.vinyl.music.amazon.dev/hls/live_static_video_audio_60s_4s_mpegts/main.m3u8`,
         description: '60s HLS video and audio mpegts stream with transmuxing',
     },
     {

--- a/packages/vinyl/src/drm/DrmControllerImpl.ts
+++ b/packages/vinyl/src/drm/DrmControllerImpl.ts
@@ -17,6 +17,7 @@ import {
     getUserAgentInfo,
     isSilentError,
     logDebug,
+    logError,
     logVerbose,
     type Maybe,
     memoize,
@@ -249,6 +250,13 @@ export class DrmControllerImpl
                 this,
                 `encrypted, initDataType: ${initDataType}, initData.byteLength: ${initData.byteLength}`
             )
+            // A session may already cover this initData (e.g. another stream
+            // created it, or buffering info was transiently cleared). Reuse it
+            // before treating the event as unconfigured content.
+            if (this.getSessionByInitData(initData)) {
+                logDebug(this, 'reusing session')
+                return
+            }
             if (!this.drmInfo?.contentProtections.length) {
                 throw new DrmError(
                     'Encrypted content not configured with content protections.'
@@ -675,6 +683,7 @@ export class DrmControllerImpl
      */
     private readonly handleError = (error: Error) => {
         if (!this._error && !isSilentError(error)) {
+            logError(this, error)
             this._error = error
             this.dispatch('error', { error, target: this })
         }

--- a/packages/vinyl/src/streaming/buffering/BufferingController.ts
+++ b/packages/vinyl/src/streaming/buffering/BufferingController.ts
@@ -276,7 +276,8 @@ export class BufferingControllerImpl
         add(this.playbackController.on('timeUpdate', this.pollBuffer))
         add(
             this.playbackController.on('seeking', () => {
-                this.clear()
+                this.reopen = true // prevents a no-op when 'ended'
+                this.pollBufferImmediate()
             })
         )
 
@@ -354,6 +355,10 @@ export class BufferingControllerImpl
                 this.refreshHead()
                 if (!this.shouldAppend()) return
                 this.reopen = false
+                if (this.needsBufferClear()) {
+                    this.clear() // After the clear, the buffer state will reset and re-poll.
+                    return
+                }
                 this.queue
                     .enqueue(() => this.appendNext())
                     .catch(this.handleError)
@@ -657,6 +662,19 @@ export class BufferingControllerImpl
         const range = this.sourceBufferController!.buffered.getRangeAt(time)
         if (!range) return 0
         return range[1] - time
+    }
+
+    /**
+     * Returns true if the playhead has become disconnected from the continuous buffer.
+     */
+    private needsBufferClear(): boolean {
+        const buffered = this.sourceBufferController!.buffered
+        if (buffered.empty) return false
+        const time = this.playbackController.currentTime
+        // The source buffer allows multiple ranges, but buffering produces a
+        // single contiguous range in practice.
+        const range = buffered.ranges[0]
+        return time < range[0] - 0.01 || time > range[1] + 0.5
     }
 
     /**

--- a/packages/vinyl/src/track/mse/MseTrack.ts
+++ b/packages/vinyl/src/track/mse/MseTrack.ts
@@ -126,6 +126,11 @@ export class MseTrack extends TrackBase {
         })
 
         this.on('bufferingQualityChange', (event) => {
+            // Keep the DRM info while a stream's buffering transiently clears
+            // (a seek or reaching the end): with multiple encrypted streams, an
+            // `encrypted` event from another stream still (re)appending its init
+            // segment needs it. The info is cleared on deactivation instead.
+            if (event.current == null) return
             this.deps.drmController.setBufferingDrmInfo(event.current, {
                 trackUri: this.uri,
                 abort: this.disposeAbort,
@@ -411,6 +416,12 @@ export class MseTrack extends TrackBase {
         this.timeUpdateSub?.()
         this.timeUpdateSub = null
         this.callOnStreams('deactivate')
+        // Streams' transient buffering clears no longer clear the DRM info, so
+        // clear it here now that the track is no longer buffering.
+        this.deps.drmController.setBufferingDrmInfo(null, {
+            trackUri: this.uri,
+            abort: this.disposeAbort,
+        })
         // Tear down the DOM text track so its cues stop showing while this
         // track is suspended (e.g. an ad playing over it). The selection is
         // retained and re-rendered on reactivation via resume().

--- a/packages/vinyl/src/vinyl/VinylPlayer.ts
+++ b/packages/vinyl/src/vinyl/VinylPlayer.ts
@@ -780,16 +780,31 @@ export class VinylPlayer<
         previous: ReadonlyTrack | null,
         current: ReadonlyTrack | null
     ): void {
-        // Active-track changes are surfaced by redispatching the previous
-        // track's controller (deactivated on switch) and the current track's
-        // controller. Here we only bridge the list-of-tracks difference,
-        // which doesn't have its own redispatched signal at track boundaries.
+        // Bridge signals that lack their own redispatched event at track
+        // boundaries. The current track's controller only emits
+        // activeTextTrackChange when a selection is *made*; on becoming current
+        // it never re-announces an already-active selection. That gap surfaces
+        // after an ad break: the content track's caption selection is preserved
+        // and re-rendered by resume() (silently), while the outgoing ad
+        // controller emits a clearing activeTextTrackChange(null) — leaving
+        // consumers that track state via events believing captions are off even
+        // though the (forced or user-selected) content caption is showing. Emit
+        // the current track's active selection so that final state is correct.
         const prevList = previous?.textTrackController?.textTracks
         const curList = current?.textTrackController?.textTracks
         if (prevList !== curList) {
             this.dispatch('textTracksChange', {
                 previous: prevList ?? [],
                 current: curList ?? [],
+            })
+        }
+        const prevActive =
+            previous?.textTrackController?.activeTextTrack ?? null
+        const curActive = current?.textTrackController?.activeTextTrack ?? null
+        if (prevActive?.id !== curActive?.id) {
+            this.dispatch('activeTextTrackChange', {
+                previous: prevActive,
+                current: curActive,
             })
         }
     }

--- a/packages/vinyl/test/integ/drm/pendingIfWidevineNotSupported.ts
+++ b/packages/vinyl/test/integ/drm/pendingIfWidevineNotSupported.ts
@@ -9,10 +9,12 @@ import { memoize } from '@amazon/vinyl-util'
 
 /**
  * Marks the test suite as pending if Widevine is not supported.
+ * Returns true if not supported.
+ *
  * @param player
  */
 export const pendingIfWidevineNotSupported = memoize(
-    async (player: VinylPlayer): Promise<void> => {
+    async (player: VinylPlayer): Promise<boolean> => {
         try {
             const response = await fetch(
                 'https://cwip-shaka-proxy.appspot.com/no_auth',
@@ -23,20 +25,20 @@ export const pendingIfWidevineNotSupported = memoize(
             )
             if (!response.ok) {
                 pending('shaka proxy rejected CORS')
-                return
+                return true
             }
         } catch (_error) {
             pending('shaka proxy could not be reached')
-            return
+            return true
         }
 
         if (location.hostname !== 'localhost') {
             pending('shaka-proxy requires localhost')
-            return
+            return true
         }
         if (!window.isSecureContext) {
             pending('requires a secure context')
-            return
+            return true
         }
         if (
             !(
@@ -47,6 +49,7 @@ export const pendingIfWidevineNotSupported = memoize(
         ) {
             pending('requires Widevine')
         }
+        return false
     },
     () => {}
 )

--- a/packages/vinyl/test/integ/playback/seeking.test.ts
+++ b/packages/vinyl/test/integ/playback/seeking.test.ts
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type VinylPlayer, type VinylTrackLoadOptions } from '@amazon/vinyl'
+import {
+    DrmKeySystem,
+    type VinylPlayer,
+    type VinylTrackLoadOptions,
+} from '@amazon/vinyl'
 import { MediaUnsupportedError, nextEventAsPromise } from '@amazon/vinyl-util'
 import {
     assertFrequency,
@@ -11,22 +15,44 @@ import {
     expectTrackCanSeekTo,
     vinylTestAssets,
 } from '@amazon/vinyl/vinylTestUtil'
+import { pendingIfWidevineNotSupported } from '../drm/pendingIfWidevineNotSupported'
 
 describe('seeking integ', () => {
-    const suite = createVinylSuite()
+    const suite = createVinylSuite({
+        drm: {
+            keySystems: {
+                [DrmKeySystem.WIDEVINE]: {
+                    licenseServer: {
+                        url: 'https://cwip-shaka-proxy.appspot.com/no_auth',
+                    },
+                },
+            },
+        },
+    })
     let player: VinylPlayer
 
     // Runs all seeking integration tests for each type of track listed.
     const trackSuites: {
         readonly description: string
         readonly track: VinylTrackLoadOptions
+        readonly needsWidevine: boolean
     }[] = [
         {
             description: 'dash with segmentBase',
+            needsWidevine: false,
             track: {
                 type: 'dash',
                 uri: vinylTestAssets.dash
                     .live_static_aac_opus_flac_60s_segmentBase,
+            },
+        },
+        {
+            description: 'dash drm video with segmentTemplate',
+            needsWidevine: true,
+            track: {
+                type: 'dash',
+                uri: vinylTestAssets.dash
+                    .live_static_video_audio_60s_2s_segmentTemplate_widevine_cl10,
             },
         },
     ]
@@ -68,6 +94,9 @@ describe('seeking integ', () => {
     for (const trackSuite of trackSuites) {
         describe(trackSuite.description, () => {
             beforeEach(async () => {
+                if (trackSuite.needsWidevine) {
+                    if (await pendingIfWidevineNotSupported(player)) return
+                }
                 try {
                     player.load(trackSuite.track)
                 } catch (error) {
@@ -124,8 +153,14 @@ describe('seeking integ', () => {
                 it('can seek close to end and start of segment boundaries', async () => {
                     await expectTrackCanSeekTo(player, 39.9)
                     await expectTrackCanSeekTo(player, 59.99)
+                    await expectTrackCanSeekTo(player, 55)
+                    await expectTrackCanSeekTo(player, 51)
+                    await expectTrackCanSeekTo(player, 49)
                     await expectTrackCanSeekTo(player, 30.01)
                     await expectTrackCanSeekTo(player, 9.999)
+                    await expectTrackCanSeekTo(player, 42)
+                    await expectTrackCanSeekTo(player, 39.995)
+                    await expectTrackCanSeekTo(player, 50.5)
                 })
 
                 it('no-ops seeks when time is close to currentTime', async () => {

--- a/packages/vinyl/test/integ/track/hls/adInterstitials.test.ts
+++ b/packages/vinyl/test/integ/track/hls/adInterstitials.test.ts
@@ -1263,9 +1263,18 @@ describe('hls ad interstitials integ (art19 real stream)', () => {
             expect(wrongPostroll)
                 .withContext('postroll must not play right after the preroll')
                 .toBeFalse()
+            // The regression is specifically the postroll jumping in after the
+            // preroll. Once the preroll ends, content resumes and advances, so
+            // this stream's midroll (startTime 5s) legitimately activates within
+            // the watch window — its presence is in fact evidence content
+            // resumed. Assert the preroll ran first and the postroll never ran,
+            // without over-constraining which content-timeline breaks played.
+            expect(enteredPlacements[0])
+                .withContext('preroll plays first')
+                .toBe('preroll')
             expect(enteredPlacements)
-                .withContext('only the preroll has played')
-                .toEqual(['preroll'])
+                .withContext('postroll must not play before content')
+                .not.toContain('postroll')
         } finally {
             sub()
         }

--- a/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
@@ -281,6 +281,25 @@ describe('DrmControllerImpl', () => {
             ])
         })
 
+        it('reuses an existing session for the same init data across calls', async () => {
+            // Two encrypted streams (e.g. audio and video) sharing an init data
+            // should share one session rather than create duplicates.
+            const withPssh = {
+                ...drmInfo,
+                contentProtections: [
+                    { keySystem: DrmKeySystem.WIDEVINE, pssh: '123' },
+                ],
+            }
+            drmController.initializeForPlayback(withPssh)
+            await flushPromises()
+            expect(mediaKeys.createSession).toHaveBeenCalledTimes(1)
+
+            drmController.initializeForPlayback(withPssh)
+            await flushPromises()
+            expect(mediaKeys.createSession).toHaveBeenCalledTimes(1) // reused
+            expect(drmController.activeSessions).toBe(1)
+        })
+
         describe('when drmInfo is missing mimeType', () => {
             it('emits an error event', async () => {
                 drmController.initializeForPlayback({
@@ -474,6 +493,26 @@ describe('DrmControllerImpl', () => {
             expectError(
                 'Encrypted content not configured with content protections.'
             )
+        })
+
+        it('reuses an existing session when buffering info has been cleared', async () => {
+            // Multiple encrypted streams share one controller. One stream can
+            // clear its buffering DRM info (a seek, or reaching the end) while
+            // another stream's re-appended init segment fires `encrypted` for
+            // the same initData. That event must reuse the existing session
+            // rather than fail as unconfigured content.
+            const initData = new Uint8Array([1, 2, 3])
+            drmController.setBufferingDrmInfo(drmInfo)
+            await emitEncrypted(initData)
+            expect(mediaKeys.createSession).toHaveBeenCalledTimes(1)
+
+            // A concurrent stream clears the shared buffering DRM info...
+            drmController.setBufferingDrmInfo(null)
+
+            // ...and the other stream's init append fires `encrypted` again.
+            await emitEncrypted(initData)
+            expect(errorSpy).not.toHaveBeenCalled()
+            expect(mediaKeys.createSession).toHaveBeenCalledTimes(1) // reused
         })
 
         describe('and the drm controller is disposed', () => {

--- a/packages/vinyl/test/unit/streaming/MseTrack.test.ts
+++ b/packages/vinyl/test/unit/streaming/MseTrack.test.ts
@@ -274,6 +274,20 @@ describe('MseTrack', () => {
             expect(deps.playbackSource.load).toHaveBeenCalledOnceWith()
             expect(deps.playbackController.pause).toHaveBeenCalledOnceWith()
         })
+
+        it('clears the drm buffering info', async () => {
+            track = createTrack()
+            await awaitContentTypes()
+            track.activate({})
+            deps.drmController.setBufferingDrmInfo.calls.reset()
+            track.deactivate()
+            expect(
+                deps.drmController.setBufferingDrmInfo
+            ).toHaveBeenCalledOnceWith(null, {
+                trackUri: 'uri',
+                abort: any(Abort),
+            })
+        })
     })
 
     describe('error', () => {
@@ -380,6 +394,21 @@ describe('MseTrack', () => {
                 trackUri: 'uri',
                 abort: any(Abort),
             })
+        })
+
+        it('keeps the drm info when a stream transiently clears its buffering quality', async () => {
+            // A seek/clear nulls a stream's buffering quality; the DRM info must
+            // be kept so another still-appending stream's `encrypted` event can
+            // resolve it. It is cleared on deactivation instead.
+            track = createTrack()
+            await awaitContentTypes()
+            getAudioStream().dispatch('bufferingQualityChange', {
+                previous: createEmptyMediaQualityMetadata(),
+                current: null,
+            })
+            expect(
+                deps.drmController.setBufferingDrmInfo
+            ).not.toHaveBeenCalled()
         })
     })
 

--- a/packages/vinyl/test/unit/streaming/buffering/BufferingController.test.ts
+++ b/packages/vinyl/test/unit/streaming/buffering/BufferingController.test.ts
@@ -593,6 +593,41 @@ describe('BufferingControllerImpl', () => {
                 expect(segmentController.getSegment).toHaveBeenCalledTimes(1)
             })
         })
+
+        describe('then seeking to an unbuffered position', () => {
+            it('reopens buffering and appends from the new position', async () => {
+                // Replace the default controller with one that buffers ahead.
+                bufferingController.dispose()
+                // Buffer two segments, then the stream ends.
+                setSegmentList([1, 1])
+                bufferingController = createBufferingController({
+                    minBuffer: 100,
+                })
+                bufferingController.activate()
+                await open()
+                await clock.tick(0, 0, 0, 0)
+                expect(bufferingController.bufferingEnded).toBeTrue()
+                expect(sourceBufferController.buffered.ranges).toEqual([
+                    [0, 20],
+                ])
+
+                // More content becomes available; seek beyond the buffered range.
+                segmentController.getSegment.and.callFake((time) =>
+                    Promise.resolve(createMockSegment(time))
+                )
+                segmentController.getSegment.calls.reset()
+                playbackController.currentTime = 50
+                playbackController.dispatch('seeking', {})
+                await clock.tick(0, 0, 0, 0)
+
+                // The reopen flag lets buffering resume despite the ended state.
+                expect(bufferingController.bufferingEnded).toBeFalse()
+                expect(segmentController.getSegment).toHaveBeenCalled()
+                expect(
+                    sourceBufferController.buffered.getRangeAt(50, 0.5)
+                ).not.toBeNull()
+            })
+        })
     })
 
     describe('when append throws a QuotaExceededError', () => {
@@ -804,12 +839,14 @@ describe('BufferingControllerImpl', () => {
                 expect(playbackQualityChange).toHaveBeenCalledTimes(1)
                 playbackQualityChange.calls.reset()
 
-                // time < 20 will still be q1
-                await setTime(12)
+                // Playback advances while buffering stays ahead of the playhead
+                // (a playhead that outruns the buffer is treated as a disconnect
+                // and clears). time < 20 will still be q1.
+                await setTime(9)
                 expect(playbackQualityChange).not.toHaveBeenCalled()
 
                 // 20-30s will now be buffered but q1 is still playing
-                await setTime(19)
+                await setTime(18)
                 expect(playbackQualityChange).not.toHaveBeenCalled()
 
                 // now moving onto q2
@@ -875,14 +912,16 @@ describe('BufferingControllerImpl', () => {
 
                 playbackQualityChange.calls.reset()
 
-                // Change back to the q1
+                // A backwards seek to a buffered position keeps the buffered
+                // data and does not trigger a quality change.
                 await setTime(changeTime - 1)
                 // A backwards time update can only happen after a seek
                 playbackController.dispatch('seeking', {})
                 await nextPollImmediate()
 
+                expect(playbackQualityChange).not.toHaveBeenCalled()
                 expect(bufferingController.playbackQuality?.qualityId).toBe(
-                    'q1'
+                    'q2'
                 )
             })
         })
@@ -952,27 +991,16 @@ describe('BufferingControllerImpl', () => {
                 })
                 bufferingQualityChange.calls.reset()
 
-                // Go back to time 0, buffering first quality
+                // A backwards seek to time 0 keeps the buffered data (no clear).
+                // The buffering frontier is unchanged, so bufferingQuality stays
+                // q2 and no change event fires.
                 playbackController.currentTime = 0
                 playbackController.dispatch('seeking', {})
                 await flushPromises()
-                expect(bufferingQualityChange).toHaveBeenCalledOnceWith({
-                    previous: objectContaining({
-                        qualityId: 'q2',
-                    }),
-                    current: null,
-                })
-                bufferingQualityChange.calls.reset()
-
                 await nextPollImmediate()
-                expect(bufferingQualityChange).toHaveBeenCalledOnceWith({
-                    previous: null,
-                    current: objectContaining({
-                        qualityId: 'q1',
-                    }),
-                })
+                expect(bufferingQualityChange).not.toHaveBeenCalled()
                 expect(bufferingController.bufferingQuality?.qualityId).toBe(
-                    'q1'
+                    'q2'
                 )
             })
         })

--- a/packages/vinyl/test/unit/vinyl/VinylPlayerTextTracks.test.ts
+++ b/packages/vinyl/test/unit/vinyl/VinylPlayerTextTracks.test.ts
@@ -240,6 +240,84 @@ describe('VinylPlayer text track API', () => {
         expect(spy).toHaveBeenCalled()
     })
 
+    it('re-announces the content caption after an ad break so it does not read as off', () => {
+        // Regression: enabling captions during an ad and then letting content
+        // resume left consumers that track state via activeTextTrackChange
+        // believing captions were off, because the outgoing ad controller emits
+        // a clearing activeTextTrackChange(null) while the content's preserved
+        // (here forced) selection is restored silently by resume().
+        const content = makeTrackWithController()
+        content.controller.setTextTracks([
+            {
+                id: 'c-forced',
+                kind: 'subtitles',
+                language: 'en',
+                label: 'English (Forced)',
+                default: true,
+                forced: true,
+                characteristics: [],
+                uri: 'c.vtt',
+                mimeType: 'text/vtt',
+            },
+        ])
+        // Forced caption auto-selects for content.
+        expect(content.controller.activeTextTrack?.id).toBe('c-forced')
+
+        const ad = makeTrackWithController()
+        ad.controller.setTextTracks([
+            {
+                id: 'ad-cc',
+                kind: 'subtitles',
+                language: 'en',
+                label: 'English',
+                default: false,
+                forced: false,
+                characteristics: [],
+                uri: 'ad.vtt',
+                mimeType: 'text/vtt',
+            },
+        ])
+
+        // Content becomes current.
+        deps.trackController.currentTrack = content.track
+        deps.trackController.dispatch('currentTrackChange', {
+            previous: null,
+            current: content.track,
+        })
+
+        // Enter the ad break: the swap preserves the content selection
+        // (suspend keeps _active) rather than clearing it.
+        deps.adController.currentAdBreak = { placement: 'midroll' } as never
+        content.controller.suspend()
+        deps.trackController.currentTrack = ad.track
+        deps.trackController.dispatch('currentTrackChange', {
+            previous: content.track,
+            current: ad.track,
+        })
+
+        // Viewer enables the ad's captions during the break.
+        player.setActiveTextTrack('ad-cc')
+        expect(player.activeTextTrack?.id).toBe('ad-cc')
+
+        // Ad ends, content resumes.
+        deps.adController.currentAdBreak = null
+        const spy = createEventSpy(player, 'activeTextTrackChange')
+        deps.trackController.currentTrack = content.track
+        content.controller.resume()
+        deps.trackController.dispatch('currentTrackChange', {
+            previous: ad.track,
+            current: content.track,
+        })
+
+        // The player reports the content's forced caption as active again and,
+        // crucially, the last active-change event announces it — not the ad's
+        // clearing null.
+        expect(player.activeTextTrack?.id).toBe('c-forced')
+        expect(spy).toHaveBeenCalled()
+        const lastCurrent = spy.calls.mostRecent().args[0].current
+        expect(lastCurrent?.id).toBe('c-forced')
+    })
+
     it('does not emit activeTextTrackChange when neither track has an active selection', () => {
         // Both tracks are text-capable but nothing is active — the current
         // track change should not manufacture a spurious active-change event.

--- a/packages/vinyl/test/vinylTestUtil/util/playback/expectTrackCanSeek.ts
+++ b/packages/vinyl/test/vinylTestUtil/util/playback/expectTrackCanSeek.ts
@@ -13,6 +13,7 @@ import {
     expectPausedState,
     expectPlayingState,
     expectTimeDoesNotElapse,
+    expectTimeElapses,
 } from './playbackStateExpectations'
 import { onPlaying } from './eventPromises'
 import { assertFrequency } from '../../media/FrequencyAnalyzer'
@@ -74,6 +75,7 @@ export async function expectTrackCanSeekTo(player: VinylPlayer, time: number) {
             await onPlaying(player)
             expectPlayingState(player)
             await assertFrequency()
+            await expectTimeElapses(player)
         }
     }
 


### PR DESCRIPTION
fix(drm): reuse DRM sessions and reopen buffering across seeks

Keep DRM info alive while a stream's buffering transiently clears (a
seek or reaching the end) so a concurrent encrypted stream re-appending
its init segment can reuse the existing session instead of failing as
unconfigured content; clear the info on track deactivation instead.

Reopen buffering on seek and clear the source buffer when the playhead
disconnects from the contiguous buffered range, so seeks past the end
of buffered content resume appending from the new position.