### PR TITLE
test: increase browserstack timeout

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -29,3 +29,15 @@ jobs:
                   BROWSERSTACK_ACCESS_KEY:
                       ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
               run: npm run test:browserstack
+
+            # Per-session console logs are written locally to bStackLogs/ and
+            # otherwise discarded when the runner is torn down. Upload them so
+            # they're downloadable from the run — including on failures and
+            # timeouts, hence `if: always()`.
+            - name: Upload BrowserStack logs
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: browserstack-logs
+                  path: packages/vinyl/bStackLogs/
+                  if-no-files-found: ignore

--- a/packages/vinyl-build-utils/src/browserstack/BrowserStackWorker.ts
+++ b/packages/vinyl-build-utils/src/browserstack/BrowserStackWorker.ts
@@ -251,7 +251,25 @@ export class BrowserStackWorker {
     private async refreshSession() {
         const state = this._state
         if (state.sessionId) {
+            const previousStatus = state.session?.status
             state.session = await this.deps.client.getSession(state.sessionId)
+            // A worker terminated by BrowserStack (e.g. the run exceeded the
+            // worker `timeout`) reports a 'timeout' status. It counts as a
+            // failure like any other, but is otherwise silent — the reporter
+            // never sends its `done`, so nothing explains the failed count.
+            // Log it clearly, once, on the transition.
+            if (
+                state.session.status === 'timeout' &&
+                previousStatus !== 'timeout'
+            ) {
+                const secs = state.workerOptions.timeout
+                logger.error(
+                    `⏱️ ${this.name} timed out${
+                        secs ? ` after ${secs}s` : ''
+                    } — worker terminated by BrowserStack before tests ` +
+                        `completed; counts as a failure`
+                )
+            }
             this.onUpdate()
         }
     }

--- a/packages/vinyl-build-utils/src/vinyl/vinylDefaultBrowserStackOptions.ts
+++ b/packages/vinyl-build-utils/src/vinyl/vinylDefaultBrowserStackOptions.ts
@@ -23,7 +23,7 @@ export const vinylDefaultBrowserStackOptions = {
     stopOnFirstFailure: true,
     workerCommon: {
         video: true,
-        timeout: 10 * 60, // 10 minutes
+        timeout: 30 * 60, // 30 minutes (BrowserStack maximum)
     },
     worker: {
         queryParams: {


### PR DESCRIPTION
New tests for ads surpass the previous 10 minute timeout limit.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
