### PR TITLE
test: log player errors in VinylSuite

### DIFF
--- a/packages/vinyl/test/vinylTestUtil/player/createVinylSuite.ts
+++ b/packages/vinyl/test/vinylTestUtil/player/createVinylSuite.ts
@@ -8,7 +8,12 @@ import {
     type VinylDependencyOptions,
     type VinylPlayer,
 } from '@amazon/vinyl'
-import type { Unsubscribe } from '@amazon/vinyl-util'
+import {
+    createDisposer,
+    logError,
+    toJson,
+    type Unsubscribe,
+} from '@amazon/vinyl-util'
 import {
     createLogPrefix,
     createRequester,
@@ -69,9 +74,11 @@ export class VinylSuite<T extends VinylPlayer<any, any> = VinylPlayer> {
      * Initializes jasmine test setup.
      */
     init() {
-        let playerErrorSub: Unsubscribe | null = null
+        let playerSub: Unsubscribe | null = null
         setTestTimeout(this.options?.timeout ?? 60)
         beforeEach(() => {
+            const { add, dispose } = createDisposer()
+            playerSub = dispose
             // Browserstack's network is flaky and prone to transient drops;
             // give integ requests more retries than the production default.
             requesterWithRetryRef.set(() =>
@@ -84,16 +91,23 @@ export class VinylSuite<T extends VinylPlayer<any, any> = VinylPlayer> {
                 this.visibilityChangeHandler
             )
             this._player = this.playerFactory()
-            if (this.options?.failOnError !== false) {
-                playerErrorSub = this._player.on('error', (e) => {
-                    fail(e)
+            add(
+                this._player.on('error', (e) => {
+                    logError(this, 'player emitted error event', toJson(e))
                 })
+            )
+            if (this.options?.failOnError !== false) {
+                add(
+                    this._player.on('error', (e) => {
+                        fail(e.error)
+                    })
+                )
             }
         })
 
         afterEach(() => {
             logDebug(this, 'disposing')
-            if (playerErrorSub) playerErrorSub()
+            if (playerSub) playerSub()
             this._player?.dispose()
             this._player = null
             document.removeEventListener(


### PR DESCRIPTION
VinylSuite now logs every player `error` event (via the logger, with the error serialized) alongside the existing failOnError handler, and manages its subscriptions through a disposer. Logging the error makes integ and BrowserStack failures diagnosable instead of only failing the spec, and the failOnError handler now reports the underlying `e.error` rather than the event wrapper.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
