### PR TITLE
ci: deploy GitHub Pages on a release tag, not from the release PR

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,6 +1,15 @@
 name: Deploy GitHub Pages
 
 on:
+    # Deploy on a release tag (pushed by release-publish.yml) or a manual run —
+    # never on ordinary pushes to main.
+    #
+    # NOTE: a tag run's ref is refs/tags/v*, so the github-pages environment's
+    # deployment protection must allow the `v*` tag pattern (Settings →
+    # Environments → github-pages → Deployment branches and tags), otherwise the
+    # deploy is rejected like any other non-main ref.
+    push:
+        tags: ['v*']
     workflow_dispatch:
         inputs:
             ref:
@@ -25,7 +34,8 @@ jobs:
         steps:
             - uses: actions/checkout@v6
               with:
-                  ref: ${{ inputs.ref }}
+                  # Tag push → the release tag; manual run → the chosen ref.
+                  ref: ${{ inputs.ref || github.ref }}
 
             - uses: actions/setup-node@v6
               with:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,3 +1,7 @@
+# Tags and publishes when a release/v* PR merges. GitHub Pages is NOT deployed
+# here: this workflow runs in the pull_request context (github.ref =
+# refs/pull/N/merge), which the github-pages environment rejects. Pushing the
+# v* tag below triggers pages-deploy.yml, which deploys Pages from that tag.
 name: Release Publish
 
 on:
@@ -18,10 +22,6 @@ jobs:
         permissions:
             contents: write
             id-token: write
-            pages: write
-        environment:
-            name: github-pages
-            url: ${{ steps.deployment.outputs.page_url }}
         steps:
             - uses: actions/checkout@v6
               with:
@@ -58,11 +58,3 @@ jobs:
 
             - name: Publish to npm
               run: npx lerna publish from-package --yes
-
-            - name: Upload Pages artifact
-              uses: actions/upload-pages-artifact@v3
-              with:
-                  path: packages/vinyl-website/dist
-
-            - name: Deploy to GitHub Pages
-              uses: actions/deploy-pages@v4


### PR DESCRIPTION
The Pages deploy lived in release-publish.yml, which is triggered by the release PR closing — so its github.ref is refs/pull/N/merge, a ref the github-pages environment rejects. Move it out: pages-deploy.yml now runs on a v* tag push (pushed by release-publish's Tag step with the release PAT) or a manual workflow_dispatch, and release-publish.yml no longer touches the github-pages environment.

Requires the github-pages environment to allow the `v*` tag ref (Deployment branches and tags), alongside `main` for manual runs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
