### PR TITLE
build: strip dev-only export condition before publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -56,5 +56,8 @@ jobs:
                   gh release create "v$(node -p
                   "require('./lerna.json').version")" --generate-notes
 
+            - name: Strip dev-only exports before publish
+              run: npm run prepare:publish
+
             - name: Publish to npm
               run: npx lerna publish from-package --yes

--- a/buildSrc/stripDevExports.ts
+++ b/buildSrc/stripDevExports.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Removes the dev-only "development" export condition from each package's
+// package.json before publishing. The `development` condition (written by
+// writePackageJsonExports.ts) points at TS source under ./src so in-monorepo
+// builds resolve cross-package imports to source. Published tarballs ship only
+// `dist`, so leaving `development` in lets a consumer that bundles with
+// esbuild `conditions: ['development']` resolve to source that isn't there and
+// fail (`Could not resolve "./src/index.ts"`). Stripping it makes such
+// consumers fall through to the "import"/"require" conditions -> ./dist.
+//
+// This mutates package.json in place. Run it only on a throwaway publish
+// checkout (CI), immediately before `lerna publish`; the working tree keeps
+// `development` for local source builds.
+//
+// Usage: tsx ./buildSrc/stripDevExports.ts
+
+import { glob } from 'glob'
+import fs from 'node:fs'
+
+// Recursively delete any "development" key within an exports subtree.
+function stripDevelopment(node: unknown): boolean {
+    if (!node || typeof node !== 'object') return false
+    let changed = false
+    for (const [key, value] of Object.entries(
+        node as Record<string, unknown>
+    )) {
+        if (key === 'development') {
+            delete (node as Record<string, unknown>)[key]
+            changed = true
+        } else if (stripDevelopment(value)) {
+            changed = true
+        }
+    }
+    return changed
+}
+
+function stripDevExports() {
+    for (const file of glob.sync('packages/*/package.json')) {
+        const pkg = JSON.parse(fs.readFileSync(file, 'utf8'))
+        if (pkg.exports && stripDevelopment(pkg.exports)) {
+            fs.writeFileSync(file, JSON.stringify(pkg, null, 4) + '\n')
+            console.log(`Stripped development exports from ${file}`)
+        }
+    }
+}
+
+stripDevExports()

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "pretest:browserstack": "lerna run build:release",
         "test:browserstack": "npm run test:browserstack -ws --if-present",
         "release": "nx run-many -t lint test:coverage build:release analyzeExports --parallel=8 && npm run prettier:check",
+        "prepare:publish": "tsx buildSrc/stripDevExports.ts",
         "start": "npm run start -w @amazon/vinyl-website",
         "watch": "lerna run watch --parallel --scope @amazon/*",
         "prepare": "husky"


### PR DESCRIPTION
The development export condition points at ./src, which published tarballs don't ship. Strip it from each package.json in a prepare:publish step before `lerna publish` so consumers bundling with esbuild conditions:['development'] resolve to dist instead of failing on unshipped source. The working tree keeps development for local source builds.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
