### PR TITLE
build: strip dev-only export condition and publish with npm

### DIFF
--- a/packages/vinyl-build-utils/package.json
+++ b/packages/vinyl-build-utils/package.json
@@ -54,5 +54,8 @@
     "dependencies": {
         "express": "^5.1.0",
         "http-proxy-middleware": "^3.0.7"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/vinyl-cache-manager/package.json
+++ b/packages/vinyl-cache-manager/package.json
@@ -74,5 +74,8 @@
     },
     "dependencies": {
         "@amazon/vinyl-util": "^2.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/vinyl-di/package.json
+++ b/packages/vinyl-di/package.json
@@ -74,5 +74,8 @@
     },
     "dependencies": {
         "@amazon/vinyl-util": "^2.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/vinyl-hls-parser/package.json
+++ b/packages/vinyl-hls-parser/package.json
@@ -95,5 +95,8 @@
     "dependencies": {
         "@amazon/vinyl-util": "^2.0.1",
         "@amazon/vinyl-validation": "^2.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/vinyl-jasmine-wrapper/package.json
+++ b/packages/vinyl-jasmine-wrapper/package.json
@@ -33,5 +33,8 @@
             "import": "./dist/index.js"
         }
     },
-    "typesVersions": {}
+    "typesVersions": {},
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/vinyl-mock-generator/package.json
+++ b/packages/vinyl-mock-generator/package.json
@@ -33,5 +33,8 @@
             "import": "./dist/index.js"
         }
     },
-    "typesVersions": {}
+    "typesVersions": {},
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/vinyl-mpd-parser/package.json
+++ b/packages/vinyl-mpd-parser/package.json
@@ -95,5 +95,8 @@
         "@amazon/vinyl-util": "^2.0.1",
         "@amazon/vinyl-validation": "^2.0.1",
         "@amazon/vinyl-xml": "^2.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/vinyl-observable/package.json
+++ b/packages/vinyl-observable/package.json
@@ -74,5 +74,8 @@
     },
     "dependencies": {
         "@amazon/vinyl-util": "^2.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/vinyl-transmux/package.json
+++ b/packages/vinyl-transmux/package.json
@@ -75,5 +75,8 @@
     },
     "dependencies": {
         "@amazon/vinyl-util": "^2.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/vinyl-tsx/package.json
+++ b/packages/vinyl-tsx/package.json
@@ -75,5 +75,8 @@
     "dependencies": {
         "@amazon/vinyl-observable": "^2.0.1",
         "@amazon/vinyl-util": "^2.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/vinyl-util/package.json
+++ b/packages/vinyl-util/package.json
@@ -114,5 +114,8 @@
         "@amazon/vinyl-build-utils": "^2.0.1",
         "@amazon/vinyl-jasmine-wrapper": "^2.0.1",
         "@amazon/vinyl-mock-generator": "^2.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/vinyl-validation/package.json
+++ b/packages/vinyl-validation/package.json
@@ -75,5 +75,8 @@
     },
     "dependencies": {
         "@amazon/vinyl-util": "^2.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/vinyl-xml/package.json
+++ b/packages/vinyl-xml/package.json
@@ -75,5 +75,8 @@
     "dependencies": {
         "@amazon/vinyl-util": "^2.0.1",
         "@amazon/vinyl-validation": "^2.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/vinyl/package.json
+++ b/packages/vinyl/package.json
@@ -103,5 +103,8 @@
         "@amazon/vinyl-transmux": "^2.0.1",
         "@amazon/vinyl-util": "^2.0.1",
         "@amazon/vinyl-validation": "^2.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }


### PR DESCRIPTION
Strip the `development` export condition (which points at ./src, not shipped in published tarballs) from each package.json before publishing, so consumers bundling with esbuild conditions:['development'] resolve to dist instead of failing on unshipped source. The working tree keeps `development` for local source builds.

Publish with `npm publish -ws` instead of `lerna publish from-package` so the strip can run without a clean-tree commit (npm publish has no such check). Set publishConfig.access=public so newly added scoped packages publish publicly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
