### PR TITLE
fix(ad): end the track after an empty postroll break

### DIFF
--- a/packages/vinyl/src/track/TrackController.ts
+++ b/packages/vinyl/src/track/TrackController.ts
@@ -398,44 +398,50 @@ export class TrackControllerImpl<TrackLoadOptionsType extends TrackLoadOptions>
                     logDebug(this, 'more adbreaks')
                     return
                 }
-                if (adParent.active) {
-                    logDebug(this, 'no ads began')
-                    return
-                }
                 const adParentLoad = this._current!
                 const placement = event.adBreak.placement
                 const isPreroll = placement === 'preroll'
                 const isPostroll = placement === 'postroll'
+                // When the content track is still active no ad ever took over
+                // (an empty break): there is no ad track to switch away from.
+                const noAdBegan = adParent.active
 
-                // A completed postroll marks the end of the whole track
-                // (content + postroll); preroll/midroll only resume content.
-                if (isPostroll) {
-                    logDebug(this, 'trackEnded after postroll')
-                    this.dispatch('trackEnded', { track: adParentLoad })
-                }
-                if (isPostroll && this.hasNext()) {
-                    this.next()
-                } else {
-                    // Overrides the config startTime to resume from the correct position.
-                    const startTime = isPreroll
-                        ? adParentLoad.config?.startTime
-                        : event.resumePosition
-                    // Resume the main track.
+                // Resumes/restores the content track at the given position.
+                const resumeContent = (startTime: Maybe<number>) =>
                     this.setCurrentTrack(adParent, {
-                        config: {
-                            ...adParentLoad.config,
-                            startTime,
-                        },
+                        config: { ...adParentLoad.config, startTime },
                         isAd: false,
                         checkPreroll: false,
                     })
-                    if (isPostroll) {
-                        logInfo(this, 'queueEnded after postroll ad(s)')
-                        this.dispatch('queueEnded', {})
-                    } else {
-                        playbackController.play().catch(noop)
+
+                if (isPostroll) {
+                    // The whole track (content + any postroll) is done.
+                    logDebug(this, 'trackEnded after postroll')
+                    this.dispatch('trackEnded', { track: adParentLoad })
+                    if (this.hasNext()) {
+                        this.next()
+                        return
                     }
+                    // Last track: restore the content track (parked at the end)
+                    // if an ad had taken over; an empty break never left it.
+                    if (!noAdBegan) resumeContent(event.resumePosition)
+                    logInfo(this, 'queueEnded after postroll')
+                    this.dispatch('queueEnded', {})
+                    return
                 }
+
+                // Preroll/midroll resume content — unless the break was empty,
+                // in which case content was never interrupted.
+                if (noAdBegan) {
+                    logDebug(this, 'no ads began')
+                    return
+                }
+                resumeContent(
+                    isPreroll
+                        ? adParentLoad.config?.startTime
+                        : event.resumePosition
+                )
+                playbackController.play().catch(noop)
             })
         )
     }

--- a/packages/vinyl/test/integ/track/hls/adInterstitials.test.ts
+++ b/packages/vinyl/test/integ/track/hls/adInterstitials.test.ts
@@ -820,6 +820,90 @@ describe('hls ad interstitials integ', () => {
             .toBeTrue()
     })
 
+    // The `empty_breaks_pre_mid_post` asset carries real pre/mid/post
+    // interstitial breaks whose asset lists resolve to zero ads — the postroll
+    // is what exercises the "content ended, empty postroll" path.
+    const EMPTY_BREAKS_ASSET =
+        vinylTestAssets.hls.vinyl_ad_breaks_av__empty_breaks_pre_mid_post
+
+    it('ends the track after an empty postroll (no ads) instead of hanging', async () => {
+        const player = suite.player
+        player.load({ type: 'hls', uri: EMPTY_BREAKS_ASSET })
+        await poll(() => (player.currentTrackAds?.adBreaks.length ?? 0) > 0, {
+            timeout: 15,
+        })
+
+        // Subscribe before driving to the end so the events can't be missed.
+        // Before the fix, an empty postroll swallowed the end: no ad began, so
+        // the adBreakCompleted handler bailed on the "no ads began" guard and
+        // never dispatched trackEnded/queueEnded — the track hung "playing"
+        // forever after `ended` deferred to the postroll.
+        const trackEnded = nextEventAsPromise(player, 'trackEnded', {
+            filter: (e) => e.track.uri === EMPTY_BREAKS_ASSET,
+            timeout: 40,
+            timeoutMessage: 'trackEnded not received for the empty postroll',
+        })
+        const queueEnded = nextEventAsPromise(player, 'queueEnded', {
+            timeout: 40,
+            timeoutMessage: 'queueEnded not received after the empty postroll',
+        })
+
+        await player.play().catch(noop)
+        // Drive content to its end so the postroll triggers on `ended`.
+        await player
+            .seekTo(Math.max(0, player.duration - 1.5), 1)
+            .catch(() => undefined)
+
+        // Single-track queue: the track ends, the queue ends, no ad played.
+        await trackEnded
+        await queueEnded
+        expect(player.currentAd)
+            .withContext('no ad played for the empty break')
+            .toBeNull()
+    })
+
+    it('advances to the next track after an empty postroll (no ads)', async () => {
+        const player = suite.player
+        const nextAsset = vinylTestAssets.hls.live_static_video_audio_60s_4s
+        player.load(
+            { type: 'hls', uri: EMPTY_BREAKS_ASSET },
+            { type: 'hls', uri: nextAsset }
+        )
+        await poll(() => (player.currentTrackAds?.adBreaks.length ?? 0) > 0, {
+            timeout: 15,
+        })
+
+        // The empty postroll ends the first track, and because a track follows
+        // in the queue, playback advances to it rather than ending the queue.
+        const firstTrackEnded = nextEventAsPromise(player, 'trackEnded', {
+            filter: (e) => e.track.uri === EMPTY_BREAKS_ASSET,
+            timeout: 40,
+            timeoutMessage: 'trackEnded not received for the first track',
+        })
+        // The filter ignores the first track's own activation.
+        const nextActivated = nextEventAsPromise(player, 'trackActivated', {
+            filter: (e) => e.track.uri === nextAsset,
+            timeout: 40,
+            timeoutMessage: 'the next queued track was not activated',
+        })
+
+        await player.play().catch(noop)
+        // Drive the first track's content to its end so the postroll triggers
+        // on `ended`.
+        await player
+            .seekTo(Math.max(0, player.duration - 1.5), 1)
+            .catch(() => undefined)
+
+        await firstTrackEnded
+        await nextActivated
+        expect(player.activeTrack?.uri)
+            .withContext('advanced to the next queued track')
+            .toBe(nextAsset)
+        expect(player.currentAd)
+            .withContext('no ad played for the empty break')
+            .toBeNull()
+    })
+
     it('does not replay a postroll after it finishes naturally', async () => {
         const player = suite.player
         // A postroll that is never suppressed re-enters on each content

--- a/packages/vinyl/test/unit/track/TrackController.test.ts
+++ b/packages/vinyl/test/unit/track/TrackController.test.ts
@@ -1650,6 +1650,50 @@ describe('TrackControllerImpl', () => {
             expect(trackActivated).toHaveBeenCalledBefore(queueEnded)
         })
 
+        it('ends the track after an empty postroll where no ad ever began', async () => {
+            // An empty postroll (a break that resolves to no ads) completes
+            // without any adEntered, so the content track is never deactivated
+            // and stays active. onEnded has already deferred the trackEnded to
+            // adBreakCompleted, so this must still end the track and the queue
+            // rather than hang.
+            const [main] = createLoadOptionsList(1)
+            trackController.load(main)
+            await clock.tick() // content activates (stays active — no ad plays)
+            expect((trackController.activeTrack as MockTrack).active).toBeTrue()
+
+            const trackEnded = createEventSpy(trackController, 'trackEnded')
+            const queueEnded = createEventSpy(trackController, 'queueEnded')
+            deps.adController.dispatch('adBreakCompleted', {
+                adBreak: adBreak('postroll'),
+                resumePosition: 0,
+            })
+            await clock.tick()
+            expect(trackEnded).toHaveBeenCalledWith(
+                objectContaining({
+                    track: objectContaining({ uri: main.uri }),
+                })
+            )
+            expect(queueEnded).toHaveBeenCalled()
+        })
+
+        it('advances to the next track after an empty postroll where no ad ever began', async () => {
+            const list = createLoadOptionsList(2)
+            trackController.load(...list)
+            await clock.tick() // content activates and stays active
+            expect((trackController.activeTrack as MockTrack).active).toBeTrue()
+
+            const trackEnded = createEventSpy(trackController, 'trackEnded')
+            deps.adController.dispatch('adBreakCompleted', {
+                adBreak: adBreak('postroll'),
+                resumePosition: 0,
+            })
+            await clock.tick()
+            expect(trackEnded).toHaveBeenCalledWith(
+                objectContaining({ track: any(Object) })
+            )
+            expect(trackController.activeTrack?.uri).toBe(list[1].uri)
+        })
+
         it('does not treat a completed midroll ad as the track ending', async () => {
             trackController.load(...createLoadOptionsList(1))
             const trackEnded = createEventSpy(trackController, 'trackEnded')


### PR DESCRIPTION
An empty postroll (a break that resolves to no ads) fired adBreakCompleted without any adEntered, so the content track stayed active and the adBreakCompleted handler bailed on the "no ads began" guard before dispatching trackEnded/queueEnded. Because onEnded had already deferred the trackEnded to the postroll, the track hung "playing" forever once content ended.

End the track and advance the queue for an empty postroll, leaving preroll/midroll (where content was never interrupted) unchanged.

Covered by unit tests for the single- and next-track cases and integ tests that drive the real empty_breaks_pre_mid_post asset to its end.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
