### PR TITLE
fix(drm): fall back to wildcard key system when resolving license server

### DIFF
--- a/packages/vinyl/src/drm/DrmControllerImpl.ts
+++ b/packages/vinyl/src/drm/DrmControllerImpl.ts
@@ -605,7 +605,8 @@ export class DrmControllerImpl
         const keySystem = mediaKeys.keySystem
         logDebug(this, 'message', keySystem, event.message.byteLength)
 
-        const keySystemOptions = this.options.keySystems[keySystem]
+        const keySystemOptions =
+            this.options.keySystems[keySystem] ?? this.options.keySystems['*']
         const licenseServerOptionsProvider = keySystemOptions?.licenseServer
 
         // Get the license server configuration for the current key system.

--- a/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
@@ -844,6 +844,31 @@ describe('DrmControllerImpl', () => {
             }
         })
 
+        it('falls back to the wildcard key system license server', async () => {
+            drmController = new DrmControllerImpl(deps, {
+                keySystems: {
+                    // Only a wildcard entry — no per-key-system configuration.
+                    '*': {
+                        licenseServer: () => ({
+                            url: 'http://example.com/wildcard',
+                        }),
+                    },
+                },
+                licenseProvider,
+            })
+
+            drmController.setBufferingDrmInfo(drmInfo)
+
+            await emitEncrypted(new Uint8Array([1, 2, 3]), 'cenc')
+            const message = new ArrayBuffer(1)
+            await emitMessage(0, message)
+            expect(licenseProvider).toHaveBeenCalledOnceWith(
+                DrmKeySystem.WIDEVINE,
+                { url: 'http://example.com/wildcard' },
+                message
+            )
+        })
+
         describe('when license takes too long to resolve', () => {
             it('emits an error event', async () => {
                 drmController = new DrmControllerImpl(deps, {


### PR DESCRIPTION
The license message handler looked up licenseServer options by the exact key system only, unlike maybeCreateSession and getMediaKeySystemOptions which fall back to the '*' wildcard entry. A wildcard-only DRM config therefore created sessions and media keys but resolved no license server at message time, so every license request failed with 'Missing licenseServer url' and only clear (clear-lead / clear-period) samples played.

Resolve the wildcard entry as a fallback, matching the other call sites.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
