### PR TITLE
fix(dash): derive period start and duration from Period@duration

### DIFF
--- a/packages/vinyl/src/track/dash/util/mpd.ts
+++ b/packages/vinyl/src/track/dash/util/mpd.ts
@@ -97,9 +97,27 @@ export function calculatePeriodTimeRange(period: PeriodType): PeriodRange {
  *
  * In a static presentation, the first period SHALL start at the zero point of the MPD timeline (with a
  * Period@start value of 0 seconds).
+ *
+ * When `Period@start` is absent, the start is derived from the sum of the
+ * preceding periods' `Period@duration` values, per the PeriodStart derivation
+ * in ISO/IEC 23009-1 §5.3.2.1. This is common in on-demand manifests that
+ * declare only per-period durations (no explicit `@start`, no
+ * `MPD@mediaPresentationDuration`).
  */
 export function calculatePeriodStart(period: PeriodType): number {
-    return period.start ?? 0
+    if (period.start != null) return period.start
+
+    const mpd = period.parent
+    const periodIndex = mpd.Period.indexOf(period)
+    if (periodIndex <= 0) return 0
+
+    const previous = mpd.Period[periodIndex - 1]
+    const previousStart = calculatePeriodStart(previous)
+    // The previous period's duration extends the timeline; without it the start
+    // cannot be advanced, so it inherits the previous period's start.
+    return previous.duration != null
+        ? previousStart + previous.duration
+        : previousStart
 }
 
 /**
@@ -113,8 +131,11 @@ export function calculatePeriodStart(period: PeriodType): number {
  * shortened by an MPD update).
  */
 export function calculatePeriodEnd(period: PeriodType): number | null {
-    if (period.start != null && period.duration != null)
-        return period.start + period.duration
+    // A period's own duration defines its end regardless of whether `@start`
+    // is explicit, since `calculatePeriodStart` derives the start from the
+    // preceding periods when `@start` is absent.
+    if (period.duration != null)
+        return calculatePeriodStart(period) + period.duration
 
     const mpd = period.parent
     const periodIndex = mpd.Period.indexOf(period)

--- a/packages/vinyl/test/unit/track/dash/util/mpd.test.ts
+++ b/packages/vinyl/test/unit/track/dash/util/mpd.test.ts
@@ -171,6 +171,33 @@ describe('mpd utils', () => {
                 expect(calculatePeriodStart(manifest.MPD.Period[0])).toEqual(0)
             })
         })
+
+        describe('when period.start is absent but periods have durations', () => {
+            it('derives the start from the preceding period durations', () => {
+                // language=XML
+                const manifest = parseDashManifest(`<?xml version="1.0" ?>
+<MPD minBufferTime="PT0.0S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011">
+  <Period duration="888.053"/>
+  <Period duration="888.053"/>
+  <Period duration="888.053"/>
+</MPD>`)
+                expect(manifest.MPD.Period.map(calculatePeriodStart)).toEqual([
+                    0, 888.053, 1776.106,
+                ])
+            })
+
+            it('inherits the previous start when the previous period has no duration', () => {
+                // language=XML
+                const manifest = parseDashManifest(`<?xml version="1.0" ?>
+<MPD minBufferTime="PT0.0S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011">
+  <Period/>
+  <Period/>
+</MPD>`)
+                // The first period has neither start nor duration, so the
+                // second period cannot advance and inherits start 0.
+                expect(calculatePeriodStart(manifest.MPD.Period[1])).toEqual(0)
+            })
+        })
     })
 
     describe('getPeriodAtTime', () => {
@@ -385,6 +412,19 @@ describe('mpd utils', () => {
   </Period>
 </MPD>`)
                 expect(calculateDuration(manifest)).toBe(50)
+            })
+        })
+
+        describe('when only per-period durations are present', () => {
+            it('sums the period durations across the presentation', () => {
+                // language=XML
+                const manifest = parseDashManifest(`<?xml version="1.0" ?>
+<MPD minBufferTime="PT0.0S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011">
+  <Period duration="888.053"/>
+  <Period duration="888.053"/>
+  <Period duration="888.053"/>
+</MPD>`)
+                expect(calculateDuration(manifest)).toBeCloseTo(2664.159, 3)
             })
         })
 


### PR DESCRIPTION
On-demand DASH manifests may declare only per-period durations, with no Period@start and no MPD@mediaPresentationDuration. calculatePeriodStart returned 0 for every such period, collapsing the timeline so only one period was ever selectable, and calculateDuration threw because the last period had no determinable end.

Derive an absent Period@start from the sum of the preceding periods' durations (ISO/IEC 23009-1 §5.3.2.1), and treat a period's own duration as defining its end regardless of whether @start is explicit. This yields a correct multi-period timeline and total presentation duration.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
