### PR TITLE
feat(website): configurable track settings (title, type, DRM)

### DIFF
--- a/packages/vinyl-website/src/components/PlayerPage.tsx
+++ b/packages/vinyl-website/src/components/PlayerPage.tsx
@@ -3,13 +3,29 @@ import {
     createTrackFromUrl,
     enqueueContent,
     loadContent,
-    type Track,
+    type DemoTrack,
+    type TrackType,
 } from '../player'
+import { DrmKeySystem, type DrmOptions } from '@amazon/vinyl'
 import { data } from '@amazon/vinyl-observable'
 import { Icon } from './icons'
 import { toastError } from './toast'
 
-const demoTracks: Track[] = [
+const TYPE_OPTIONS: readonly (TrackType | 'auto')[] = [
+    'auto',
+    'dash',
+    'hls',
+    'src',
+]
+
+const KEY_SYSTEM_OPTIONS: readonly { value: DrmKeySystem; label: string }[] = [
+    { value: DrmKeySystem.WIDEVINE, label: 'Widevine' },
+    { value: DrmKeySystem.PLAY_READY, label: 'PlayReady' },
+    { value: DrmKeySystem.FAIR_PLAY, label: 'FairPlay' },
+    { value: DrmKeySystem.CLEAR_KEY, label: 'Clear Key' },
+]
+
+const demoTracks: DemoTrack[] = [
     {
         title: 'Audio Only (DASH)',
         type: 'dash',
@@ -44,7 +60,7 @@ const demoTracks: Track[] = [
 // configuration embedded in the manifest, so they load like any other HLS
 // track — no separate ad config is passed to the player. Grouped into a
 // collapsed section below; descriptions state what each scenario exercises.
-const adBreakTracks: Track[] = [
+const adBreakTracks: DemoTrack[] = [
     {
         title: 'Apple SGAI Sample',
         type: 'hls',
@@ -142,23 +158,67 @@ const adBreakTracks: Track[] = [
 
 export function PlayerPage() {
     const url$ = data('')
+    const title$ = data('')
+    const type$ = data<TrackType | 'auto'>('auto')
+    const keySystem$ = data<DrmKeySystem>(DrmKeySystem.WIDEVINE)
+    const licenseServerUrl$ = data('')
+    const serverCertificateUrl$ = data('')
+
+    // Builds a DRM configuration from the settings fields, fetching the service
+    // certificate to bytes when a URL is given. Returns undefined when no
+    // license server is set, so unprotected content is unaffected. Keyed by the
+    // selected key system; the DemoTrack config still allows configuring every key
+    // system programmatically.
+    const buildDrmOptions = async (): Promise<
+        Partial<DrmOptions> | undefined
+    > => {
+        const url = licenseServerUrl$.value.trim()
+        if (!url) return undefined
+        const certUrl = serverCertificateUrl$.value.trim()
+        const serverCertificate = certUrl
+            ? await fetch(certUrl).then((r) => r.arrayBuffer())
+            : undefined
+        return {
+            keySystems: {
+                [keySystem$.value]: {
+                    licenseServer: {
+                        url,
+                        ...(serverCertificate && { serverCertificate }),
+                    },
+                },
+            },
+        }
+    }
+
     // Resolves the currently typed URL to a track, then hands it to `sink`
     // (play now or enqueue).
-    const withUrlTrack = (sink: (track: Track) => void) => {
+    const withUrlTrack = async (sink: (track: DemoTrack) => void) => {
         const url = url$.value.trim()
         if (!url) return
-        createTrackFromUrl(url)
-            .then((track) => {
-                if (!track) {
-                    toastError('Could not determine media type for URL')
-                    return
-                }
-                sink(track)
-            })
-            .catch(toastError)
+        const drm = await buildDrmOptions()
+        const track = await createTrackFromUrl(url, {
+            type: type$.value,
+            ...(title$.value.trim() && { title: title$.value.trim() }),
+            ...(drm && { drm }),
+        })
+        if (!track) {
+            toastError('Could not determine media type for URL')
+            return
+        }
+        sink(track)
     }
-    const loadUrl = () => withUrlTrack(loadContent)
-    const enqueueUrl = () => withUrlTrack(enqueueContent)
+    const loadUrl = () => {
+        withUrlTrack(loadContent).catch(toastError)
+    }
+    const enqueueUrl = () => {
+        withUrlTrack(enqueueContent).catch(toastError)
+    }
+
+    const bindValue = (target: { value: string }) => (e: Event) => {
+        target.value = (
+            e.currentTarget as HTMLInputElement | HTMLSelectElement
+        ).value
+    }
 
     return (
         <div className="page">
@@ -166,34 +226,125 @@ export function PlayerPage() {
                 <div className="cardHeader">
                     <h2>Add Content</h2>
                 </div>
-                <div className="urlRow">
-                    <input
-                        className="textInput"
-                        type="text"
-                        aria-label="Manifest or media source URL"
-                        placeholder="Enter manifest URL (.mpd, .m3u8) or media source"
-                        oninput={(e) => {
-                            url$.value = (
-                                e.currentTarget as HTMLInputElement
-                            ).value
-                        }}
-                        onkeydown={(e) => {
-                            if (e.key === 'Enter') loadUrl()
-                        }}
-                    />
-                    <button className="btn btnPrimary" onclick={loadUrl}>
-                        <Icon name="play_arrow" />
-                        Play
-                    </button>
-                    <button
-                        className="btnIcon"
-                        title="Add to queue"
-                        aria-label="Add to queue"
-                        onclick={enqueueUrl}
-                    >
-                        <Icon name="add" />
-                    </button>
-                </div>
+                {/* A real form so the browser records field values for native
+                    autocomplete: named inputs are remembered on submit (Enter
+                    or Play). We preventDefault to keep it a client-side load. */}
+                <form
+                    autocomplete="on"
+                    onsubmit={(e: Event) => {
+                        e.preventDefault()
+                        loadUrl()
+                    }}
+                >
+                    <div className="urlRow">
+                        <input
+                            className="textInput"
+                            type="text"
+                            name="manifestUrl"
+                            autocomplete="on"
+                            aria-label="Manifest or media source URL"
+                            placeholder="Enter manifest URL (.mpd, .m3u8) or media source"
+                            oninput={(e) => {
+                                url$.value = (
+                                    e.currentTarget as HTMLInputElement
+                                ).value
+                            }}
+                        />
+                        <button className="btn btnPrimary" type="submit">
+                            <Icon name="play_arrow" />
+                            Play
+                        </button>
+                        <button
+                            className="btnIcon"
+                            type="button"
+                            title="Add to queue"
+                            aria-label="Add to queue"
+                            onclick={enqueueUrl}
+                        >
+                            <Icon name="add" />
+                        </button>
+                    </div>
+
+                    {/* Collapsed by default: `details` with no `open` attribute. */}
+                    <details className="trackSettings">
+                        <summary className="trackSettingsSummary">
+                            <Icon name="chevron_right" />
+                            <span>Track settings (title, type, DRM)</span>
+                        </summary>
+                        <div className="settingsGrid">
+                            <label className="settingsField settingsFieldWide">
+                                <span className="settingsLabel">
+                                    Title (display only)
+                                </span>
+                                <input
+                                    className="textInput"
+                                    type="text"
+                                    name="trackTitle"
+                                    autocomplete="on"
+                                    aria-label="Track title"
+                                    placeholder="Optional display name for this track"
+                                    oninput={bindValue(title$)}
+                                />
+                            </label>
+                            <label className="settingsField">
+                                <span className="settingsLabel">Type</span>
+                                <select
+                                    className="selectInput"
+                                    aria-label="Track type"
+                                    onchange={bindValue(type$)}
+                                >
+                                    {...TYPE_OPTIONS.map((t) => (
+                                        <option value={t}>{t}</option>
+                                    ))}
+                                </select>
+                            </label>
+                            <label className="settingsField">
+                                <span className="settingsLabel">
+                                    Key system
+                                </span>
+                                <select
+                                    className="selectInput"
+                                    aria-label="DRM key system"
+                                    onchange={bindValue(keySystem$)}
+                                >
+                                    {...KEY_SYSTEM_OPTIONS.map((k) => (
+                                        <option value={k.value}>
+                                            {k.label}
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
+                            <label className="settingsField settingsFieldWide">
+                                <span className="settingsLabel">
+                                    License server URL
+                                </span>
+                                <input
+                                    className="textInput"
+                                    type="text"
+                                    name="licenseServerUrl"
+                                    autocomplete="on"
+                                    aria-label="License server URL"
+                                    placeholder="https://…/proxy (leave blank for clear content)"
+                                    oninput={bindValue(licenseServerUrl$)}
+                                />
+                            </label>
+                            <label className="settingsField settingsFieldWide">
+                                <span className="settingsLabel">
+                                    Service certificate URL (optional)
+                                </span>
+                                <input
+                                    className="textInput"
+                                    type="text"
+                                    name="serviceCertificateUrl"
+                                    autocomplete="on"
+                                    aria-label="Service certificate URL"
+                                    placeholder="https://…/service-cert"
+                                    oninput={bindValue(serverCertificateUrl$)}
+                                />
+                            </label>
+                        </div>
+                    </details>
+                </form>
             </div>
 
             <div className="card">
@@ -223,7 +374,7 @@ export function PlayerPage() {
     )
 }
 
-function DemoGrid(props: { readonly tracks: readonly Track[] }) {
+function DemoGrid(props: { readonly tracks: readonly DemoTrack[] }) {
     return (
         <div className="demoGrid">
             {...props.tracks.map((track) => <DemoCard track={track} />)}
@@ -231,7 +382,7 @@ function DemoGrid(props: { readonly tracks: readonly Track[] }) {
     )
 }
 
-function DemoCard(props: { readonly track: Track }) {
+function DemoCard(props: { readonly track: DemoTrack }) {
     const { track } = props
     // Two sibling buttons (play + queue) rather than a button-role card
     // wrapping a button, which would be a nested interactive control.

--- a/packages/vinyl-website/src/player.ts
+++ b/packages/vinyl-website/src/player.ts
@@ -8,10 +8,12 @@ import {
     type AdBreakInfo,
     type AdBreakList,
     createVinylPlayer,
+    type DrmOptions,
     inferTrackTypeFromUrl,
     type MediaQualityMetadata,
     type SeekRange,
     type TextTrackInfo,
+    type TrackConfigOptions,
     HtmlTextTrackRenderer,
 } from '@amazon/vinyl'
 import { data } from '@amazon/vinyl-observable'
@@ -47,11 +49,14 @@ player.configure({
     },
 })
 
+// The player's per-track load options (a union of the registered track types).
+type PlayerLoadOptions = Parameters<typeof player.load>[0]
+
 // Observables for Vinyl State to use in TSX bindings.
 export const playerState = {
     player,
     media,
-    track$: data<Track | null>(null),
+    track$: data<DemoTrack | null>(null),
     hasVideo$: data(false),
     paused$: data(true),
     currentTime$: data(0),
@@ -194,26 +199,83 @@ player.on('adTimeUpdate', ({ adTimeRemaining, canSkip, skipIn }) => {
 
 export type TrackType = 'dash' | 'hls' | 'src'
 
-export interface Track {
-    readonly url: string
-    readonly type: TrackType
+/**
+ * Display-only metadata carried on a load's `config.extra`, so the queue view
+ * can label items (which are the raw {@link @amazon/vinyl!TrackLoadOptions},
+ * not this website's `DemoTrack`).
+ */
+export interface TrackDisplayInfo {
     readonly title?: string
     readonly description?: string
     readonly contentType?: 'video' | 'audio'
 }
 
-export function loadContent(track: Track) {
+/**
+ * A track in the player demo. `config` carries the player's per-track
+ * {@link @amazon/vinyl!TrackConfigOptions} — notably `drm` (a full
+ * {@link @amazon/vinyl!DrmOptions} that can configure every key system), plus
+ * `startTime` and `extra` — set on a demo track or from the track settings UI.
+ * Named to avoid colliding with `@amazon/vinyl`'s `Track`.
+ */
+export interface DemoTrack {
+    readonly url: string
+    readonly type: TrackType
+    readonly title?: string
+    readonly description?: string
+    readonly contentType?: 'video' | 'audio'
+    readonly config?: TrackConfigOptions
+}
+
+/**
+ * Converts a website {@link DemoTrack} into the player's {@link @amazon/vinyl!TrackLoadOptions}.
+ * The per-track `config` (drm, startTime, existing extra) is forwarded, and the
+ * display fields are stashed on `config.extra` so the queue view can render
+ * them.
+ */
+function toLoadOptions(track: DemoTrack): PlayerLoadOptions {
+    const displayInfo: TrackDisplayInfo = {
+        ...(track.title != null && { title: track.title }),
+        ...(track.description != null && { description: track.description }),
+        ...(track.contentType != null && { contentType: track.contentType }),
+    }
+    const config: TrackConfigOptions = {
+        ...track.config,
+        extra: { ...track.config?.extra, ...displayInfo },
+    }
+    return { type: track.type, uri: track.url, config }
+}
+
+export function loadContent(track: DemoTrack) {
     playerState.track$.value = track
     playerState.hasVideo$.value = track.contentType === 'video'
-    player.load({ type: track.type, uri: track.url })
+    player.load(toLoadOptions(track))
     player.play().catch(handleError)
 }
 
-export async function createTrackFromUrl(url: string): Promise<Track | null> {
+export interface CreateTrackOptions {
+    /** Overrides the inferred track type. `'auto'` (or unset) infers from the URL. */
+    readonly type?: TrackType | 'auto'
+    readonly title?: string
+    /** Full DRM configuration (may target one or many key systems). */
+    readonly drm?: Partial<DrmOptions>
+}
+
+export async function createTrackFromUrl(
+    url: string,
+    options?: CreateTrackOptions
+): Promise<DemoTrack | null> {
     if (!url) return null
-    const type = await inferTrackTypeFromUrl(url)
+    const type =
+        options?.type && options.type !== 'auto'
+            ? options.type
+            : await inferTrackTypeFromUrl(url)
     if (!type) return null
-    return { url, type }
+    return {
+        url,
+        type,
+        ...(options?.title && { title: options.title }),
+        ...(options?.drm && { config: { drm: options.drm } }),
+    }
 }
 
 /**
@@ -221,12 +283,12 @@ export async function createTrackFromUrl(url: string): Promise<Track | null> {
  * to yet, so playback simply starts; otherwise the track plays after the
  * current one (and anything already queued) finishes.
  */
-export function enqueueContent(track: Track) {
+export function enqueueContent(track: DemoTrack) {
     if (playerState.track$.value == null) {
         loadContent(track)
         return
     }
-    player.enqueue({ type: track.type, uri: track.url })
+    player.enqueue(toLoadOptions(track))
     toast(`Queued ${track.title ?? track.url}`)
 }
 

--- a/packages/vinyl-website/src/styles/components.scss
+++ b/packages/vinyl-website/src/styles/components.scss
@@ -282,6 +282,95 @@
     }
 }
 
+// Collapsible per-track settings (type + DRM), under the URL row.
+.trackSettings {
+    margin-top: var(--space-md);
+
+    .trackSettingsSummary {
+        display: flex;
+        align-items: center;
+        gap: var(--space-sm);
+        cursor: pointer;
+        list-style: none;
+        user-select: none;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+
+        &::-webkit-details-marker {
+            display: none;
+        }
+
+        .iconContainer {
+            display: inline-flex;
+            transition: transform var(--transition-fast);
+            flex-shrink: 0;
+        }
+    }
+
+    &[open] .trackSettingsSummary .iconContainer {
+        transform: rotate(90deg);
+    }
+
+    .settingsGrid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--space-md);
+        margin-top: var(--space-md);
+    }
+
+    .settingsField {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-xs);
+        min-width: 0;
+    }
+
+    // A field that should span the full width of the grid (e.g. URLs).
+    .settingsFieldWide {
+        grid-column: 1 / -1;
+    }
+
+    .settingsLabel {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+    }
+}
+
+// Native <select>, styled to match .textInput.
+.selectInput {
+    // Replace the native dropdown arrow with a custom caret so it can be inset
+    // from the right edge (the native arrow hugs the edge and ignores padding).
+    appearance: none;
+    -webkit-appearance: none;
+    padding: var(--space-sm) var(--space-md);
+    // Extra right padding leaves room for the caret so option text never
+    // collides with it.
+    padding-right: calc(var(--space-md) + 20px);
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-input-border);
+    background-color: var(--color-input-bg);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    // Inset the caret from the right edge.
+    background-position: right var(--space-md) center;
+    background-size: 12px;
+    color: var(--color-text-primary);
+    font-size: 14px;
+    font-family: inherit;
+    outline: none;
+    cursor: pointer;
+    transition:
+        border-color var(--transition-fast),
+        box-shadow var(--transition-fast);
+
+    &:focus-visible {
+        border-color: var(--color-input-focus);
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+}
+
 // Toggle switch
 .themeSwitch {
     display: flex;


### PR DESCRIPTION
The player demo could only load a URL with an auto-detected type and no way to set a display title or DRM, so protected streams (e.g. Widevine) could not be played from the demo.

Add a collapsible "Track settings" section to the Add Content card: a display-only title, a type override (auto/dash/hls/src), and DRM fields (key system, license server URL, optional service-certificate URL). A DemoTrack (renamed from Track to avoid clashing with @amazon/vinyl's Track) carries an optional config: TrackConfigOptions, so per-track drm — a full DrmOptions that can target every key system — plus startTime/extra ride along; DRM is applied per load via config.drm rather than at player construction. Display fields are stashed on config.extra.

The Add Content inputs live in a real form with named fields, so the browser's native autocomplete remembers previously entered URLs, titles, and license servers on submit.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
