### PR TITLE
perf(build): parallelize analyzeExports and move typedoc off the rele…

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -44,7 +44,9 @@ jobs:
 
             - run: npm ci
 
-            - run: npm run build:release -w @amazon/vinyl-website
+            # build:pages runs typedoc (API docs) then build:release. typedoc is
+            # kept out of build:release so the release/CI build stays fast.
+            - run: npm run build:pages -w @amazon/vinyl-website
 
             - name: Upload Pages artifact
               uses: actions/upload-pages-artifact@v3

--- a/packages/vinyl-build-utils/src/esbuild/analyzeExports.ts
+++ b/packages/vinyl-build-utils/src/esbuild/analyzeExports.ts
@@ -9,7 +9,6 @@ import fs from 'fs/promises'
 import os from 'os'
 import { exit } from 'process'
 import esbuild from 'esbuild'
-import crypto from 'node:crypto'
 
 const write = process.argv.includes('--write')
 
@@ -17,30 +16,44 @@ async function getBundleSize(
     importName: string,
     importPath: string
 ): Promise<number> {
-    const virtualEntry = path.join(
-        os.tmpdir(),
-        `analyze-exports-${importName}-${crypto.randomUUID()}.js`
-    )
-    await fs.writeFile(
-        virtualEntry,
-        `import { ${importName} } from "${importPath}";\nconsole.log(${importName});`
-    )
+    // A `stdin` entry avoids writing (and cleaning up) a temp file per export;
+    // the absolute `importPath` resolves regardless of `resolveDir`.
+    const result = await esbuild.build({
+        stdin: {
+            contents: `import { ${importName} } from ${JSON.stringify(importPath)};\nconsole.log(${importName});`,
+            resolveDir: path.dirname(importPath),
+            loader: 'js',
+        },
+        bundle: true,
+        write: false,
+        treeShaking: true,
+        minify: true,
+        format: 'esm',
+        platform: 'node',
+        logLevel: 'silent',
+    })
+    return result.outputFiles[0].text.length
+}
 
-    try {
-        const result = await esbuild.build({
-            entryPoints: [virtualEntry],
-            bundle: true,
-            write: false,
-            treeShaking: true,
-            minify: true,
-            format: 'esm',
-            platform: 'node',
-            logLevel: 'silent',
-        })
-        return result.outputFiles[0].text.length
-    } finally {
-        await fs.unlink(virtualEntry).catch(() => undefined)
-    }
+/**
+ * Runs `task` over every item with at most `concurrency` in flight. Order is
+ * not preserved; each task writes its own result.
+ */
+async function forEachConcurrent<T>(
+    items: readonly T[],
+    concurrency: number,
+    task: (item: T) => Promise<void>
+): Promise<void> {
+    let next = 0
+    const runners = Array.from(
+        { length: Math.min(concurrency, items.length) },
+        async () => {
+            while (next < items.length) {
+                await task(items[next++])
+            }
+        }
+    )
+    await Promise.all(runners)
 }
 
 export interface AnalyzeExportsOptions {
@@ -62,14 +75,23 @@ export async function analyzeExports({
     const exports = await import(importPath)
     const exportNames = Object.keys(exports)
 
-    for (const name of exportNames) {
-        try {
-            exportSizes[name] = await getBundleSize(name, importPath)
-        } catch (err: any) {
-            exportSizes[name] = -1 // Mark error
-            console.error(`Failed to bundle "${name}":`, err.message)
+    // Each export is bundled independently to measure its tree-shaken size;
+    // the builds are independent, so run them concurrently (bounded by CPUs).
+    await forEachConcurrent(
+        exportNames,
+        Math.max(1, os.cpus().length),
+        async (exportName) => {
+            try {
+                exportSizes[exportName] = await getBundleSize(
+                    exportName,
+                    importPath
+                )
+            } catch (err: any) {
+                exportSizes[exportName] = -1 // Mark error
+                console.error(`Failed to bundle "${exportName}":`, err.message)
+            }
         }
-    }
+    )
 
     const validSizes = Object.values(exportSizes).filter((size) => size > 0)
     const minBundleSize = validSizes.length > 0 ? Math.min(...validSizes) : 0

--- a/packages/vinyl-website/package.json
+++ b/packages/vinyl-website/package.json
@@ -12,7 +12,8 @@
     "scripts": {
         "start": "vite",
         "build": "vite build",
-        "build:release": "npm run typecheck && npm run typedoc && vite build",
+        "build:release": "npm run typecheck && vite build",
+        "build:pages": "npm run typedoc && npm run build:release",
         "prepreview": "npm run build",
         "preview": "vite preview",
         "typecheck": "tsc --noEmit -p tsconfig.lint.json",


### PR DESCRIPTION
…ase build

analyzeExports bundled each export sequentially, writing a temp entry file per export (160 for @amazon/vinyl) — ~10s for vinyl alone. Bundle from an in-memory stdin entry instead of a temp file, and run the independent per-export builds through a CPU-bounded concurrency pool (~10s → ~2s for vinyl).

typedoc (~8.5s) generated the API-docs site inside the website build:release, on the release/CI critical path though only the deployed site needs it. Move it to a deploy-only build:pages script (typedoc + build:release) and have pages-deploy.yml use that; build:release now just typechecks and builds.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
