### PR TITLE
Fix/audio sample rate filter and fail fast

### DIFF
--- a/packages/vinyl/src/streaming/AudioOptions.ts
+++ b/packages/vinyl/src/streaming/AudioOptions.ts
@@ -4,7 +4,14 @@
  */
 
 import type { ObjectSchema } from '@amazon/vinyl-validation'
-import { array, boolean, object, string } from '@amazon/vinyl-validation'
+import {
+    array,
+    boolean,
+    number,
+    object,
+    string,
+} from '@amazon/vinyl-validation'
+import type { Maybe } from '@amazon/vinyl-util'
 
 /**
  * Criteria used to pick which audio rendition to play.
@@ -42,10 +49,29 @@ export interface AudioOptions {
      * The audio selection criteria (language / descriptive).
      */
     readonly selection?: AudioSelection
+
+    /**
+     * When `true`, disables the audio sampling-rate support filter, so audio
+     * renditions whose sampling rate exceeds what the platform reports (via the
+     * `AudioContext` output rate) are kept and offered to playback anyway.
+     * `false` (the default) applies the filter. Changing this re-filters the
+     * timeline immediately.
+     */
+    readonly disableSampleRateFilter?: boolean
+
+    /**
+     * The maximum audio sampling rate (Hz) the sampling-rate filter treats as
+     * supported. When set, it takes precedence over the platform's
+     * `AudioContext`-reported output rate. Ignored when
+     * {@link disableSampleRateFilter} is `true`. Changing this re-filters the
+     * timeline immediately. `null`/`undefined` falls back to the reported rate.
+     */
+    readonly maxSampleRate?: Maybe<number>
 }
 
 export const defaultAudioOptions: AudioOptions = {
     selection: { language: null, descriptive: false },
+    disableSampleRateFilter: false,
 }
 
 const audioSelectionValidator: ObjectSchema<AudioSelection> = object({
@@ -55,4 +81,6 @@ const audioSelectionValidator: ObjectSchema<AudioSelection> = object({
 
 export const audioOptionsValidator: ObjectSchema<AudioOptions> = object({
     selection: audioSelectionValidator.optional(),
+    disableSampleRateFilter: boolean().optional(),
+    maxSampleRate: number().maybe().optional(),
 })

--- a/packages/vinyl/src/streaming/AudioOptions.ts
+++ b/packages/vinyl/src/streaming/AudioOptions.ts
@@ -67,6 +67,17 @@ export interface AudioOptions {
      * timeline immediately. `null`/`undefined` falls back to the reported rate.
      */
     readonly maxSampleRate?: Maybe<number>
+
+    /**
+     * The minimum audio sampling rate (Hz) the sampling-rate filter treats as
+     * supported. When set, renditions below it are filtered out as a soft floor
+     * (if every audio rendition is below it, the highest is kept so playback is
+     * never stranded). Applied alongside the max cap whenever the filter runs,
+     * regardless of how the max was determined; ignored when
+     * {@link disableSampleRateFilter} is `true`. Changing this re-filters the
+     * timeline immediately.
+     */
+    readonly minSampleRate?: Maybe<number>
 }
 
 export const defaultAudioOptions: AudioOptions = {
@@ -83,4 +94,5 @@ export const audioOptionsValidator: ObjectSchema<AudioOptions> = object({
     selection: audioSelectionValidator.optional(),
     disableSampleRateFilter: boolean().optional(),
     maxSampleRate: number().maybe().optional(),
+    minSampleRate: number().maybe().optional(),
 })

--- a/packages/vinyl/src/streaming/createDefaultMediaTimelineTransformer.ts
+++ b/packages/vinyl/src/streaming/createDefaultMediaTimelineTransformer.ts
@@ -26,8 +26,8 @@ import {
     throwKeySystemsUnsupported,
 } from '../track/filters/keySystemFilter'
 import {
-    supportsAudioSamplingRate,
     throwSamplingRatesUnsupported,
+    withinAudioSampleRateRange,
 } from '../track/filters/sampleRateFilter'
 import { throwLanguagesUnsupported } from '../track/filters/languageFilter'
 import type { CodecOverrides } from '../util/media/codecOverrides'
@@ -88,14 +88,15 @@ export function createDefaultMediaTimelineTransformer(
         // The sampling-rate filter can be turned off via audio options, keeping
         // renditions the platform reports as unsupported.
         if (!audio.disableSampleRateFilter) {
-            const sampleRateDeps = {
+            const sampleRateOptions = {
                 capabilities: deps.capabilities,
                 maxSampleRate: audio.maxSampleRate ?? null,
+                minSampleRate: audio.minSampleRate ?? null,
             }
             t = filterTimelineQualities(
                 (quality, index, array) =>
-                    supportsAudioSamplingRate(
-                        sampleRateDeps,
+                    withinAudioSampleRateRange(
+                        sampleRateOptions,
                         quality,
                         index,
                         array

--- a/packages/vinyl/src/streaming/createDefaultMediaTimelineTransformer.ts
+++ b/packages/vinyl/src/streaming/createDefaultMediaTimelineTransformer.ts
@@ -74,7 +74,7 @@ export function createDefaultMediaTimelineTransformer(
     async function transformTimeline(
         timeline: MediaTimeline
     ): Promise<MediaTimeline> {
-        const codecOverrides = deps.options.value.codecOverrides
+        const { audio, codecOverrides } = deps.options.value
         let t = filterTimelineQualities(
             (quality) => canPlayWithOverrides(quality, codecOverrides),
             throwMimeTypesUnsupported,
@@ -85,12 +85,25 @@ export function createDefaultMediaTimelineTransformer(
             throwKeySystemsUnsupported,
             t
         )
-        t = filterTimelineQualities(
-            (quality, index, array) =>
-                supportsAudioSamplingRate(deps, quality, index, array),
-            throwSamplingRatesUnsupported,
-            t
-        )
+        // The sampling-rate filter can be turned off via audio options, keeping
+        // renditions the platform reports as unsupported.
+        if (!audio.disableSampleRateFilter) {
+            const sampleRateDeps = {
+                capabilities: deps.capabilities,
+                maxSampleRate: audio.maxSampleRate ?? null,
+            }
+            t = filterTimelineQualities(
+                (quality, index, array) =>
+                    supportsAudioSamplingRate(
+                        sampleRateDeps,
+                        quality,
+                        index,
+                        array
+                    ),
+                throwSamplingRatesUnsupported,
+                t
+            )
+        }
         // Resolve audio-description eligibility BEFORE the language filter.
         // Description renditions are an accessibility opt-in, not general audio,
         // so they must be gated out (unless opted in via audio.selection.descriptive)
@@ -101,7 +114,7 @@ export function createDefaultMediaTimelineTransformer(
         // described audio they never opted into. With this gate first, the
         // language filter only ever picks among eligible (main, or opted-in
         // description) renditions.
-        const selection = deps.options.value.audio.selection
+        const selection = audio.selection
         t = filterTimelineQualities(
             createAudioDescriptionFilter(selection?.descriptive ?? false),
             throwNoPlayableAudio,

--- a/packages/vinyl/src/track/dash/DashMediaQualityMetadataResolver.ts
+++ b/packages/vinyl/src/track/dash/DashMediaQualityMetadataResolver.ts
@@ -182,13 +182,17 @@ export function createMediaQualityMetadataFromDashRepresentation(
 }
 
 /**
- * Estimates the total bandwidth a representation would use when paired with
- * proportionally matched qualities from sibling content types.
+ * Estimates the total bandwidth a representation uses alongside sibling content
+ * types, pairing it with the cheapest sibling rendition in its proportional
+ * bucket.
  *
- * For each sibling content type, the representation's relative position within its own
- * content type's sorted bandwidth list is mapped to the corresponding position in the
- * sibling's list. This produces realistic pairings — e.g. with video [v1,v2,v3,v4] and
- * audio [a1,a2], v1 pairs with a1, v2 with a1, v3 with a2, v4 with a2.
+ * Each content type's sorted list is split into as many buckets as this
+ * representation's own list has tiers; the representation is paired with the
+ * cheapest sibling rendition in the matching bucket. A stream with few tiers
+ * therefore stays selected across the span of a finer sibling's tiers (e.g. the
+ * top audio across the top half of video tiers) rather than being pinned to a
+ * single endpoint — with video [v1..v4] and audio [a1,a2], a1's bucket is
+ * v1..v2 so a1 pairs with v2, and a2's bucket is v3..v4 so a2 pairs with v4.
  */
 export function estimatePeakBandwidth(
     representation: RepresentationType,
@@ -203,13 +207,14 @@ export function estimatePeakBandwidth(
         0,
         sortedInsertionIndex(own, representation.bandwidth, (a, b) => b - a) - 1
     )
-    const position = own.length <= 1 ? 0 : ownIndex / (own.length - 1)
     let total = representation.bandwidth
     for (const [ct, bandwidths] of sortedByType) {
         if (ct === contentType) continue
+        // The cheapest peer in this tier's bucket: bucket j spans peer indices
+        // up to ceil((j+1)/ownLen * peerLen) - 1.
         const peerIndex = Math.min(
-            Math.round(position * (bandwidths.length - 1)),
-            bandwidths.length - 1
+            bandwidths.length - 1,
+            Math.ceil(((ownIndex + 1) / own.length) * bandwidths.length) - 1
         )
         total += bandwidths[peerIndex]
     }

--- a/packages/vinyl/src/track/filters/sampleRateFilter.ts
+++ b/packages/vinyl/src/track/filters/sampleRateFilter.ts
@@ -20,7 +20,8 @@ export function throwSamplingRatesUnsupported(): never {
 }
 
 /**
- * Returns true when the media's sampling rate is supported.
+ * Returns true when the media's sampling rate is supported. Only audio content
+ * types are gated; every other content type passes through.
  * If Firefox (which does not support >48kHz), filter out all sampling rates above the supported sampling rate.
  * All other browsers filter out all sampling rates above the supported sampling rate unless this will filter all
  * and then do not filter the lowest sampling rate.
@@ -31,33 +32,43 @@ export function supportsAudioSamplingRate(
     _index: number,
     array: ArrayLike<MediaQualityMetadata>
 ): boolean {
+    // Only audio renditions are gated on sampling rate; video and any other
+    // content type (including muxed video that happens to carry an audio rate)
+    // pass through untouched.
+    if (metadata.contentType !== 'audio') return true
+
     const isFirefox = hasBrowser(Browser.FIREFOX)
     const maxSampleRate = deps.capabilities.sampleRate
     const samplingRate = last(metadata.audioSamplingRate)
 
-    if (!samplingRate || !maxSampleRate) return true // sampling rate not set
+    // Unknown rate, or no AudioContext to gauge platform support: keep. This
+    // also lets >48kHz through on Firefox (its cap below is skipped) — accepted.
+    if (!samplingRate || !maxSampleRate) return true
 
     if (isFirefox) {
-        // Firefox: filter out all sampling rates above 48_000 Hz
+        // Firefox cannot decode >48kHz (e.g. high-res FLAC) via MSE; drop those.
         return samplingRate <= 48_000
     }
 
     // Other browsers: filter out all sampling rates above supported unless this will filter all
     if (samplingRate <= maxSampleRate) return true
 
-    // Check if filtering all would remove everything
-    const allAboveMax = every(array, (item) => {
-        const itemSamplingRate = last(item.audioSamplingRate)
-        return itemSamplingRate != null && itemSamplingRate > maxSampleRate
-    })
+    // Every audio rendition exceeds the platform max: keep the lowest so
+    // playback isn't stranded. Only audio qualities are considered — other
+    // content types (e.g. a co-present video rendition with no audio rate)
+    // aren't gated here and must not influence the fallback.
+    const audioSamplingRates = map(array, (item) =>
+        item.contentType === 'audio' ? last(item.audioSamplingRate) : undefined
+    ).filter((rate): rate is number => rate != null)
+
+    const allAboveMax = every(
+        audioSamplingRates,
+        (rate) => rate > maxSampleRate
+    )
 
     if (allAboveMax) {
         // Find the lowest sampling rate and only allow that one
-        const samplingRates = map(array, (item) =>
-            last(item.audioSamplingRate)
-        ).filter((rate): rate is number => rate != null)
-        const lowestSamplingRate = min(samplingRates)
-        return samplingRate === lowestSamplingRate
+        return samplingRate === min(audioSamplingRates)
     }
 
     return false

--- a/packages/vinyl/src/track/filters/sampleRateFilter.ts
+++ b/packages/vinyl/src/track/filters/sampleRateFilter.ts
@@ -27,7 +27,14 @@ export function throwSamplingRatesUnsupported(): never {
  * and then do not filter the lowest sampling rate.
  */
 export function supportsAudioSamplingRate(
-    deps: { readonly capabilities: Capabilities },
+    deps: {
+        readonly capabilities: Capabilities
+        /**
+         * An explicit maximum sampling rate that takes precedence over the
+         * platform's `AudioContext`-reported output rate when set.
+         */
+        readonly maxSampleRate?: number | null
+    },
     metadata: MediaQualityMetadata,
     _index: number,
     array: ArrayLike<MediaQualityMetadata>
@@ -38,7 +45,9 @@ export function supportsAudioSamplingRate(
     if (metadata.contentType !== 'audio') return true
 
     const isFirefox = hasBrowser(Browser.FIREFOX)
-    const maxSampleRate = deps.capabilities.sampleRate
+    // An explicit maxSampleRate takes precedence over the AudioContext-reported
+    // output rate.
+    const maxSampleRate = deps.maxSampleRate ?? deps.capabilities.sampleRate
     const samplingRate = last(metadata.audioSamplingRate)
 
     // Unknown rate, or no AudioContext to gauge platform support: keep. This

--- a/packages/vinyl/src/track/filters/sampleRateFilter.ts
+++ b/packages/vinyl/src/track/filters/sampleRateFilter.ts
@@ -11,6 +11,7 @@ import {
     MediaUnsupportedError,
     every,
     map,
+    max,
     min,
 } from '@amazon/vinyl-util'
 import type { Capabilities } from '../../client/Capabilities'
@@ -19,22 +20,31 @@ export function throwSamplingRatesUnsupported(): never {
     throw new MediaUnsupportedError('No supported sample rate', 'sampling-rate')
 }
 
+export interface AudioSampleRateRangeOptions {
+    readonly capabilities: Capabilities
+    /**
+     * An explicit maximum sampling rate that takes precedence over the
+     * platform's `AudioContext`-reported output rate when set.
+     */
+    readonly maxSampleRate?: number | null
+    /** An optional minimum sampling-rate floor. */
+    readonly minSampleRate?: number | null
+}
+
 /**
- * Returns true when the media's sampling rate is supported. Only audio content
- * types are gated; every other content type passes through.
- * If Firefox (which does not support >48kHz), filter out all sampling rates above the supported sampling rate.
- * All other browsers filter out all sampling rates above the supported sampling rate unless this will filter all
- * and then do not filter the lowest sampling rate.
+ * Returns true when the media's sampling rate is within the supported range.
+ * Only audio content types are gated; every other content type passes through.
+ *
+ * The upper bound is `maxSampleRate` when set, otherwise the platform's
+ * `AudioContext`-reported output rate (Firefox is hard-capped at 48kHz, which it
+ * cannot decode beyond via MSE). The optional lower bound is `minSampleRate`.
+ * Both bounds are soft: if every audio rendition is above the max the lowest is
+ * kept, and if every audio rendition is below the min the highest is kept, so
+ * playback is never stranded. Only audio renditions count toward those
+ * fallbacks — a co-present video quality (no audio rate) never influences them.
  */
-export function supportsAudioSamplingRate(
-    deps: {
-        readonly capabilities: Capabilities
-        /**
-         * An explicit maximum sampling rate that takes precedence over the
-         * platform's `AudioContext`-reported output rate when set.
-         */
-        readonly maxSampleRate?: number | null
-    },
+export function withinAudioSampleRateRange(
+    options: AudioSampleRateRangeOptions,
     metadata: MediaQualityMetadata,
     _index: number,
     array: ArrayLike<MediaQualityMetadata>
@@ -44,41 +54,45 @@ export function supportsAudioSamplingRate(
     // pass through untouched.
     if (metadata.contentType !== 'audio') return true
 
-    const isFirefox = hasBrowser(Browser.FIREFOX)
-    // An explicit maxSampleRate takes precedence over the AudioContext-reported
-    // output rate.
-    const maxSampleRate = deps.maxSampleRate ?? deps.capabilities.sampleRate
     const samplingRate = last(metadata.audioSamplingRate)
+    if (!samplingRate) return true // sampling rate not set
 
-    // Unknown rate, or no AudioContext to gauge platform support: keep. This
-    // also lets >48kHz through on Firefox (its cap below is skipped) — accepted.
-    if (!samplingRate || !maxSampleRate) return true
+    const audioRates = () =>
+        map(array, (item) =>
+            item.contentType === 'audio'
+                ? last(item.audioSamplingRate)
+                : undefined
+        ).filter((rate): rate is number => rate != null)
 
-    if (isFirefox) {
+    // Lower bound (soft floor), independent of the platform max: below it, keep
+    // only the highest when every audio rendition is below the floor.
+    const { minSampleRate } = options
+    if (minSampleRate != null && samplingRate < minSampleRate) {
+        const rates = audioRates()
+        return (
+            every(rates, (rate) => rate < minSampleRate) &&
+            samplingRate === max(rates)
+        )
+    }
+
+    // Upper bound. An explicit maxSampleRate takes precedence over the
+    // AudioContext-reported output rate.
+    const maxSampleRate =
+        options.maxSampleRate ?? options.capabilities.sampleRate
+    // No platform max to gauge support: keep. This also lets >48kHz through on
+    // Firefox (its cap below is skipped) — accepted.
+    if (!maxSampleRate) return true
+
+    if (hasBrowser(Browser.FIREFOX)) {
         // Firefox cannot decode >48kHz (e.g. high-res FLAC) via MSE; drop those.
         return samplingRate <= 48_000
     }
 
-    // Other browsers: filter out all sampling rates above supported unless this will filter all
     if (samplingRate <= maxSampleRate) return true
-
-    // Every audio rendition exceeds the platform max: keep the lowest so
-    // playback isn't stranded. Only audio qualities are considered — other
-    // content types (e.g. a co-present video rendition with no audio rate)
-    // aren't gated here and must not influence the fallback.
-    const audioSamplingRates = map(array, (item) =>
-        item.contentType === 'audio' ? last(item.audioSamplingRate) : undefined
-    ).filter((rate): rate is number => rate != null)
-
-    const allAboveMax = every(
-        audioSamplingRates,
-        (rate) => rate > maxSampleRate
+    // Above the max: keep only the lowest when every audio rendition exceeds it.
+    const rates = audioRates()
+    return (
+        every(rates, (rate) => rate > maxSampleRate) &&
+        samplingRate === min(rates)
     )
-
-    if (allAboveMax) {
-        // Find the lowest sampling rate and only allow that one
-        return samplingRate === min(audioSamplingRates)
-    }
-
-    return false
 }

--- a/packages/vinyl/src/track/mse/MseTrack.ts
+++ b/packages/vinyl/src/track/mse/MseTrack.ts
@@ -12,6 +12,7 @@ import {
     IntersectionRanges,
     logDebug,
     type Maybe,
+    MediaUnsupportedError,
     noop,
     type ReadonlyRanges,
     type ReadonlySet,
@@ -135,7 +136,10 @@ export class MseTrack extends TrackBase {
         add(
             deps.contentTypesValue.onData((contentTypesPromise) => {
                 contentTypesPromise
-                    .then((value) => this.setContentTypes(value))
+                    .then((value) => {
+                        this.setContentTypes(value)
+                        this.validateRequiredContentTypesPlayable()
+                    })
                     .catch(this.errorHandler)
             })
         )
@@ -256,7 +260,36 @@ export class MseTrack extends TrackBase {
                     })
                 }
             }
+            this.validateRequiredContentTypesPlayable()
         })
+    }
+
+    /**
+     * Fails fast when a media content type the manifest declared (audio/video)
+     * has no playable qualities left after timeline filtering. Its stream can
+     * never create a source buffer, so without this the track waits forever for
+     * a source buffer that never arrives, surfacing only as an opaque
+     * `readyToAppend` timeout. Runs once both the required content types and the
+     * filtered timeline qualities are known (either order).
+     */
+    private validateRequiredContentTypesPlayable(): void {
+        const qualities = this._qualities
+        if (!qualities) return
+        const present = new Set(qualities.map((q) => q.contentType))
+        // contentTypesValue only ever yields audio/video (text is a sidecar
+        // pipeline, never an MSE source buffer), so every required type must
+        // have a playable quality left in the filtered timeline.
+        for (const contentType of this._contentTypes) {
+            if (!present.has(contentType)) {
+                this.errorHandler(
+                    new MediaUnsupportedError(
+                        `No playable ${contentType} rendition`,
+                        `no-playable-${contentType}`
+                    )
+                )
+                return
+            }
+        }
     }
 
     async getAds(): Promise<TrackAds> {

--- a/packages/vinyl/test/unit/streaming/MseTrack.test.ts
+++ b/packages/vinyl/test/unit/streaming/MseTrack.test.ts
@@ -24,7 +24,7 @@ import {
 import { createEventSpy, useMockLogger } from '@amazon/vinyl-util/testUtil'
 import { flushPromises, useMockTime } from '@amazon/vinyl-util/browserTestUtil'
 import { externalDependencies } from '@amazon/vinyl-di'
-import { Abort } from '@amazon/vinyl-util'
+import { Abort, MediaUnsupportedError } from '@amazon/vinyl-util'
 import any = jasmine.any
 
 describe('MseTrack', () => {
@@ -811,6 +811,41 @@ describe('MseTrack', () => {
             await flushPromises()
             expect(track.qualities).toEqual([qualityMetadata])
             expect(track.qualitiesUnfiltered).toEqual([qualityMetadata])
+        })
+
+        it('fails fast when a required content type is entirely filtered out', async () => {
+            // contentTypes (from the manifest) is {audio, video}, but the
+            // transformed timeline has only a video quality — audio was fully
+            // filtered. The audio stream could never create a source buffer, so
+            // the track must fail rather than stall on the readyToAppend wait.
+            const videoQuality = {
+                ...createEmptyMediaQualityMetadata(),
+                contentType: 'video' as const,
+                qualityId: 'v1',
+            }
+            setTimeline({
+                periods: [
+                    {
+                        startTime: 0,
+                        endTime: 100,
+                        qualities: [
+                            {
+                                metadata: videoQuality,
+                                getSegment: () => Promise.resolve(null),
+                            },
+                        ],
+                    },
+                ],
+                minBufferTime: 2,
+                getAdBreaks: () => Promise.resolve([]),
+                getDuration: () => Promise.resolve(Infinity),
+            })
+            track = createTrack()
+            await flushPromises()
+            expect(track.error).toEqual(any(MediaUnsupportedError))
+            expect((track.error as { code?: string }).code).toBe(
+                'no-playable-audio'
+            )
         })
 
         it('reads qualities from the filtered timeline but qualitiesUnfiltered from the raw one', async () => {

--- a/packages/vinyl/test/unit/streaming/createDefaultMediaTimelineTransformer.test.ts
+++ b/packages/vinyl/test/unit/streaming/createDefaultMediaTimelineTransformer.test.ts
@@ -499,6 +499,52 @@ describe('createDefaultMediaTimelineTransformer', () => {
         unsub()
     })
 
+    it('applies audio.minSampleRate as a soft floor at runtime', async () => {
+        capabilities.sampleRate = 192_000 // max cap drops nothing
+        const timeline: MediaTimeline = {
+            periods: [
+                {
+                    startTime: 0,
+                    endTime: 100,
+                    qualities: [
+                        createQuality({
+                            contentType: 'audio',
+                            mimeType: 'audio/mp4',
+                            qualityId: 'a48',
+                            audioSamplingRate: [48_000],
+                        }),
+                        createQuality({
+                            contentType: 'audio',
+                            mimeType: 'audio/mp4',
+                            qualityId: 'a24',
+                            audioSamplingRate: [24_000],
+                        }),
+                    ],
+                },
+            ],
+            minBufferTime: 2,
+            getAdBreaks: () => Promise.resolve([]),
+            getDuration: () => Promise.resolve(Infinity),
+        }
+        const options = data({ audio: {} })
+        const transformed = createDefaultMediaTimelineTransformer({
+            capabilities,
+            drmController,
+            mediaTimeline: data(Promise.resolve(timeline)),
+            options,
+        })
+        const unsub = transformed.onData(() => {})
+        const ids = (t: MediaTimeline) =>
+            t.periods[0].qualities.map((q) => q.metadata.qualityId)
+
+        expect(ids(await transformed.value)).toEqual(['a48', 'a24'])
+
+        // Floor at 48kHz: the 24kHz rendition is dropped.
+        options.value = { audio: { minSampleRate: 48_000 } }
+        expect(ids(await transformed.value)).toEqual(['a48'])
+        unsub()
+    })
+
     it('preserves minBufferTime', async () => {
         const timeline: MediaTimeline = {
             periods: [

--- a/packages/vinyl/test/unit/streaming/createDefaultMediaTimelineTransformer.test.ts
+++ b/packages/vinyl/test/unit/streaming/createDefaultMediaTimelineTransformer.test.ts
@@ -403,6 +403,102 @@ describe('createDefaultMediaTimelineTransformer', () => {
         unsub()
     })
 
+    it('disables the sampling-rate filter via audio options at runtime', async () => {
+        // Output device at 44.1kHz: the 96kHz rendition is normally dropped
+        // (a 44.1kHz alternative exists, so the keep-lowest fallback declines).
+        capabilities.sampleRate = 44_100
+        const timeline: MediaTimeline = {
+            periods: [
+                {
+                    startTime: 0,
+                    endTime: 100,
+                    qualities: [
+                        createQuality({
+                            contentType: 'audio',
+                            mimeType: 'audio/mp4',
+                            qualityId: 'a44',
+                            audioSamplingRate: [44_100],
+                        }),
+                        createQuality({
+                            contentType: 'audio',
+                            mimeType: 'audio/mp4',
+                            qualityId: 'a96',
+                            audioSamplingRate: [96_000],
+                        }),
+                    ],
+                },
+            ],
+            minBufferTime: 2,
+            getAdBreaks: () => Promise.resolve([]),
+            getDuration: () => Promise.resolve(Infinity),
+        }
+        const options = data({ audio: { disableSampleRateFilter: false } })
+        const transformed = createDefaultMediaTimelineTransformer({
+            capabilities,
+            drmController,
+            mediaTimeline: data(Promise.resolve(timeline)),
+            options,
+        })
+        const unsub = transformed.onData(() => {})
+        const ids = (t: MediaTimeline) =>
+            t.periods[0].qualities.map((q) => q.metadata.qualityId)
+
+        // Filter on: the 96kHz rendition is dropped.
+        expect(ids(await transformed.value)).toEqual(['a44'])
+
+        // Filter off: both renditions are kept.
+        options.value = { audio: { disableSampleRateFilter: true } }
+        expect(ids(await transformed.value)).toEqual(['a44', 'a96'])
+        unsub()
+    })
+
+    it('honors audio.maxSampleRate over the reported rate at runtime', async () => {
+        // AudioContext reports 48kHz, so the 96kHz rendition is dropped.
+        capabilities.sampleRate = 48_000
+        const timeline: MediaTimeline = {
+            periods: [
+                {
+                    startTime: 0,
+                    endTime: 100,
+                    qualities: [
+                        createQuality({
+                            contentType: 'audio',
+                            mimeType: 'audio/mp4',
+                            qualityId: 'a48',
+                            audioSamplingRate: [48_000],
+                        }),
+                        createQuality({
+                            contentType: 'audio',
+                            mimeType: 'audio/mp4',
+                            qualityId: 'a96',
+                            audioSamplingRate: [96_000],
+                        }),
+                    ],
+                },
+            ],
+            minBufferTime: 2,
+            getAdBreaks: () => Promise.resolve([]),
+            getDuration: () => Promise.resolve(Infinity),
+        }
+        const options = data({ audio: {} })
+        const transformed = createDefaultMediaTimelineTransformer({
+            capabilities,
+            drmController,
+            mediaTimeline: data(Promise.resolve(timeline)),
+            options,
+        })
+        const unsub = transformed.onData(() => {})
+        const ids = (t: MediaTimeline) =>
+            t.periods[0].qualities.map((q) => q.metadata.qualityId)
+
+        expect(ids(await transformed.value)).toEqual(['a48'])
+
+        // Raise the cap to 96kHz: the 96kHz rendition is now kept.
+        options.value = { audio: { maxSampleRate: 96_000 } }
+        expect(ids(await transformed.value)).toEqual(['a48', 'a96'])
+        unsub()
+    })
+
     it('preserves minBufferTime', async () => {
         const timeline: MediaTimeline = {
             periods: [

--- a/packages/vinyl/test/unit/track/dash/DashMediaQualityMetadataResolver.test.ts
+++ b/packages/vinyl/test/unit/track/dash/DashMediaQualityMetadataResolver.test.ts
@@ -539,7 +539,7 @@ describe('getPeriodSortedBandwidths', () => {
 })
 
 describe('estimatePeakBandwidth', () => {
-    it('pairs proportionally when video has more qualities than audio', () => {
+    it('pairs each tier with the cheapest peer in its bucket', () => {
         // language=XML
         const m = parseDashManifest(`<?xml version="1.0" ?>
             <MPD minBufferTime="PT0S" profiles="" xmlns="urn:mpeg:dash:schema:mpd:2011">
@@ -558,29 +558,65 @@ describe('estimatePeakBandwidth', () => {
             </MPD>`)
         const as0 = m.MPD.Period[0].AdaptationSet![0]
         const as1 = m.MPD.Period[0].AdaptationSet![1]
-        // video sorted: [4000, 3000, 2000, 1000], audio sorted: [200, 100]
-        // v1 pos=0/3=0.00 → audio index round(0.00*1)=0 → 200. total=4200
+        // video sorted: [4000, 3000, 2000, 1000], audio sorted: [200, 100].
+        // Video's two audio buckets: v1,v2 → a1(200); v3,v4 → a2(100).
         expect(estimatePeakBandwidth(as0.Representation![0], 'video')).toBe(
             4200
         )
-        // v2 pos=1/3=0.33 → audio index round(0.33*1)=0 → 200. total=3200
         expect(estimatePeakBandwidth(as0.Representation![1], 'video')).toBe(
             3200
         )
-        // v3 pos=2/3=0.67 → audio index round(0.67*1)=1 → 100. total=2100
         expect(estimatePeakBandwidth(as0.Representation![2], 'video')).toBe(
             2100
         )
-        // v4 pos=3/3=1.00 → audio index round(1.00*1)=1 → 100. total=1100
         expect(estimatePeakBandwidth(as0.Representation![3], 'video')).toBe(
             1100
         )
-        // a1 pos=0/1=0 → video index round(0*3)=0 → 4000. total=4200
+        // Audio's two video buckets: a1's bucket is v1,v2 so it pairs with the
+        // cheapest of those (v2=3000); a2's bucket is v3,v4 (cheapest v4=1000).
         expect(estimatePeakBandwidth(as1.Representation![0], 'audio')).toBe(
-            4200
+            3200
         )
-        // a2 pos=1/1=1 → video index round(1*3)=3 → 1000. total=1100
         expect(estimatePeakBandwidth(as1.Representation![1], 'audio')).toBe(
+            1100
+        )
+    })
+
+    it('does not pin a small stream to its lowest tier across a finer peer', () => {
+        // 2 audio tiers alongside 10 video tiers: the top audio must stay
+        // affordable across the whole top half of video, not only at the very
+        // top. (Regression: it was priced with the single top video.)
+        // language=XML
+        const m = parseDashManifest(`<?xml version="1.0" ?>
+            <MPD minBufferTime="PT0S" profiles="" xmlns="urn:mpeg:dash:schema:mpd:2011">
+                <Period>
+                    <AdaptationSet mimeType="video/mp4" codecs="avc1.640015">
+                        <Representation bandwidth="10000" id="v1"/>
+                        <Representation bandwidth="9000" id="v2"/>
+                        <Representation bandwidth="8000" id="v3"/>
+                        <Representation bandwidth="7000" id="v4"/>
+                        <Representation bandwidth="6000" id="v5"/>
+                        <Representation bandwidth="5000" id="v6"/>
+                        <Representation bandwidth="4000" id="v7"/>
+                        <Representation bandwidth="3000" id="v8"/>
+                        <Representation bandwidth="2000" id="v9"/>
+                        <Representation bandwidth="1000" id="v10"/>
+                    </AdaptationSet>
+                    <AdaptationSet mimeType="audio/mp4" codecs="mp4a.40.2">
+                        <Representation bandwidth="200" id="a1"/>
+                        <Representation bandwidth="100" id="a2"/>
+                    </AdaptationSet>
+                </Period>
+            </MPD>`)
+        const audio = m.MPD.Period[0].AdaptationSet![1]
+        // Top audio's bucket is video[0..4]; it pairs with the cheapest of those
+        // (video[4]=6000), NOT video[0]=10000. So its total is 6200, keeping it
+        // affordable for the top half of video tiers.
+        expect(estimatePeakBandwidth(audio.Representation![0], 'audio')).toBe(
+            6200
+        )
+        // Bottom audio's bucket is video[5..9]; cheapest video[9]=1000 → 1100.
+        expect(estimatePeakBandwidth(audio.Representation![1], 'audio')).toBe(
             1100
         )
     })
@@ -629,7 +665,7 @@ describe('estimatePeakBandwidth', () => {
         ).toBe(50000)
     })
 
-    it('pairs proportionally with three content types', () => {
+    it('pairs with the cheapest peer bucket across three content types', () => {
         // language=XML
         const m = parseDashManifest(`<?xml version="1.0" ?>
             <MPD minBufferTime="PT0S" profiles="" xmlns="urn:mpeg:dash:schema:mpd:2011">
@@ -647,27 +683,28 @@ describe('estimatePeakBandwidth', () => {
                     </AdaptationSet>
                 </Period>
             </MPD>`)
-        // v1 pos=0 → audio[0]=200, text[0]=10. total=2210
+        // v1 → cheapest audio in its bucket (200) + cheapest text (10). total=2210
         expect(
             estimatePeakBandwidth(
                 m.MPD.Period[0].AdaptationSet![0].Representation![0],
                 'video'
             )
         ).toBe(2210)
-        // v2 pos=1 → audio[1]=100, text[0]=10. total=1110
+        // v2 → audio bucket cheapest (100) + text (10). total=1110
         expect(
             estimatePeakBandwidth(
                 m.MPD.Period[0].AdaptationSet![0].Representation![1],
                 'video'
             )
         ).toBe(1110)
-        // t1 pos=0 (only 1 text) → video[0]=2000, audio[0]=200. total=2210
+        // t1 is the only text tier, so its bucket spans every peer — it pairs
+        // with the cheapest video (1000) and cheapest audio (100). total=1110
         expect(
             estimatePeakBandwidth(
                 m.MPD.Period[0].AdaptationSet![2].Representation![0],
                 'text'
             )
-        ).toBe(2210)
+        ).toBe(1110)
     })
 
     it('handles single quality per content type', () => {

--- a/packages/vinyl/test/unit/track/filters/sampleRateFilter.test.ts
+++ b/packages/vinyl/test/unit/track/filters/sampleRateFilter.test.ts
@@ -134,6 +134,63 @@ describe('supportsAudioSamplingRate', () => {
             ).toBe(false)
         })
 
+        it('an explicit maxSampleRate takes precedence — raising it keeps a higher rate', () => {
+            // AudioContext reports 48kHz, which would drop the 96kHz rendition.
+            capabilities.sampleRate = 48_000
+            const low = audioQuality([48_000])
+            const high = audioQuality([96_000])
+
+            // Without an override, 96kHz is dropped (a 48kHz alternative exists).
+            expect(
+                supportsAudioSamplingRate({ capabilities }, high, 1, [
+                    low,
+                    high,
+                ])
+            ).toBe(false)
+
+            // With maxSampleRate = 96kHz, it is kept.
+            expect(
+                supportsAudioSamplingRate(
+                    { capabilities, maxSampleRate: 96_000 },
+                    high,
+                    1,
+                    [low, high]
+                )
+            ).toBe(true)
+        })
+
+        it('an explicit maxSampleRate takes precedence — lowering it drops a rate the platform allows', () => {
+            // AudioContext reports 192kHz, which would keep the 96kHz rendition.
+            capabilities.sampleRate = 192_000
+            const low = audioQuality([48_000])
+            const high = audioQuality([96_000])
+
+            expect(
+                supportsAudioSamplingRate({ capabilities }, high, 1, [
+                    low,
+                    high,
+                ])
+            ).toBe(true)
+
+            // Capping at 48kHz drops the 96kHz rendition and keeps the 48kHz one.
+            expect(
+                supportsAudioSamplingRate(
+                    { capabilities, maxSampleRate: 48_000 },
+                    high,
+                    1,
+                    [low, high]
+                )
+            ).toBe(false)
+            expect(
+                supportsAudioSamplingRate(
+                    { capabilities, maxSampleRate: 48_000 },
+                    low,
+                    0,
+                    [low, high]
+                )
+            ).toBe(true)
+        })
+
         it('ignores non-audio qualities and keeps audio above the device rate', () => {
             // Output device runs at 44.1kHz while the audio is standard 48kHz.
             capabilities.sampleRate = 44_100

--- a/packages/vinyl/test/unit/track/filters/sampleRateFilter.test.ts
+++ b/packages/vinyl/test/unit/track/filters/sampleRateFilter.test.ts
@@ -19,14 +19,22 @@ describe('supportsAudioSamplingRate', () => {
         capabilities.sampleRate = 48_000
     })
 
+    // The filter only gates audio content types, so gated fixtures must declare
+    // contentType 'audio' (the empty metadata defaults it to null).
+    function audioQuality(rate: number[] | null) {
+        const quality = createEmptyMediaQualityMetadata()
+        quality.contentType = 'audio'
+        quality.audioSamplingRate = rate
+        return quality
+    }
+
     describe('when browser is Firefox', () => {
         beforeEach(() => {
             setUserAgent('Firefox')
         })
 
         it('returns false when sample rate is above supported', () => {
-            const metadata = createEmptyMediaQualityMetadata()
-            metadata.audioSamplingRate = [96_000]
+            const metadata = audioQuality([96_000])
 
             expect(
                 supportsAudioSamplingRate({ capabilities }, metadata, 0, [
@@ -37,8 +45,7 @@ describe('supportsAudioSamplingRate', () => {
 
         it('returns false when sample rate is above 48kHz even if capabilities allows it', () => {
             capabilities.sampleRate = 96_000
-            const metadata = createEmptyMediaQualityMetadata()
-            metadata.audioSamplingRate = [96_000]
+            const metadata = audioQuality([96_000])
 
             expect(
                 supportsAudioSamplingRate({ capabilities }, metadata, 0, [
@@ -48,10 +55,8 @@ describe('supportsAudioSamplingRate', () => {
         })
 
         it('returns false even when all rates are above 48kHz (no fallback to lowest)', () => {
-            const low = createEmptyMediaQualityMetadata()
-            low.audioSamplingRate = [88_200]
-            const high = createEmptyMediaQualityMetadata()
-            high.audioSamplingRate = [96_000]
+            const low = audioQuality([88_200])
+            const high = audioQuality([96_000])
 
             expect(
                 supportsAudioSamplingRate({ capabilities }, low, 0, [low, high])
@@ -66,8 +71,7 @@ describe('supportsAudioSamplingRate', () => {
         })
 
         it('returns true when sample rate is at or below supported', () => {
-            const metadata = createEmptyMediaQualityMetadata()
-            metadata.audioSamplingRate = [48_000]
+            const metadata = audioQuality([48_000])
 
             expect(
                 supportsAudioSamplingRate({ capabilities }, metadata, 0, [
@@ -77,8 +81,7 @@ describe('supportsAudioSamplingRate', () => {
         })
 
         it('returns true when sample rate is not set', () => {
-            const metadata = createEmptyMediaQualityMetadata()
-            metadata.audioSamplingRate = null
+            const metadata = audioQuality(null)
 
             expect(
                 supportsAudioSamplingRate({ capabilities }, metadata, 0, [
@@ -94,8 +97,7 @@ describe('supportsAudioSamplingRate', () => {
         })
 
         it('returns true when sample rate is at or below supported', () => {
-            const metadata = createEmptyMediaQualityMetadata()
-            metadata.audioSamplingRate = [48_000]
+            const metadata = audioQuality([48_000])
 
             expect(
                 supportsAudioSamplingRate({ capabilities }, metadata, 0, [
@@ -105,10 +107,8 @@ describe('supportsAudioSamplingRate', () => {
         })
 
         it('returns false when sample rate is above supported and others are below', () => {
-            const low = createEmptyMediaQualityMetadata()
-            low.audioSamplingRate = [44_100]
-            const high = createEmptyMediaQualityMetadata()
-            high.audioSamplingRate = [96_000]
+            const low = audioQuality([44_100])
+            const high = audioQuality([96_000])
 
             expect(
                 supportsAudioSamplingRate({ capabilities }, high, 1, [
@@ -119,10 +119,8 @@ describe('supportsAudioSamplingRate', () => {
         })
 
         it('keeps lowest sample rate when all are above supported', () => {
-            const low = createEmptyMediaQualityMetadata()
-            low.audioSamplingRate = [88_200]
-            const high = createEmptyMediaQualityMetadata()
-            high.audioSamplingRate = [96_000]
+            const low = audioQuality([88_200])
+            const high = audioQuality([96_000])
 
             expect(
                 supportsAudioSamplingRate({ capabilities }, low, 0, [low, high])
@@ -134,6 +132,30 @@ describe('supportsAudioSamplingRate', () => {
                     high,
                 ])
             ).toBe(false)
+        })
+
+        it('ignores non-audio qualities and keeps audio above the device rate', () => {
+            // Output device runs at 44.1kHz while the audio is standard 48kHz.
+            capabilities.sampleRate = 44_100
+            const audio = audioQuality([48_000])
+            // A co-present video quality is never gated and must not influence
+            // the audio keep-lowest fallback.
+            const video = createEmptyMediaQualityMetadata()
+            video.contentType = 'video'
+            video.audioSamplingRate = null
+
+            expect(
+                supportsAudioSamplingRate({ capabilities }, audio, 0, [
+                    audio,
+                    video,
+                ])
+            ).toBe(true)
+            expect(
+                supportsAudioSamplingRate({ capabilities }, video, 1, [
+                    audio,
+                    video,
+                ])
+            ).toBe(true)
         })
     })
 

--- a/packages/vinyl/test/unit/track/filters/sampleRateFilter.test.ts
+++ b/packages/vinyl/test/unit/track/filters/sampleRateFilter.test.ts
@@ -4,14 +4,14 @@
  */
 
 import {
-    supportsAudioSamplingRate,
+    withinAudioSampleRateRange,
     createEmptyMediaQualityMetadata,
     throwSamplingRatesUnsupported,
 } from '@amazon/vinyl'
 import { MockCapabilities } from '@amazon/vinyl/vinylTestUtil'
 import { setUserAgent } from '@amazon/vinyl-util'
 
-describe('supportsAudioSamplingRate', () => {
+describe('withinAudioSampleRateRange', () => {
     let capabilities: MockCapabilities
 
     beforeEach(() => {
@@ -37,7 +37,7 @@ describe('supportsAudioSamplingRate', () => {
             const metadata = audioQuality([96_000])
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, metadata, 0, [
+                withinAudioSampleRateRange({ capabilities }, metadata, 0, [
                     metadata,
                 ])
             ).toBe(false)
@@ -48,7 +48,7 @@ describe('supportsAudioSamplingRate', () => {
             const metadata = audioQuality([96_000])
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, metadata, 0, [
+                withinAudioSampleRateRange({ capabilities }, metadata, 0, [
                     metadata,
                 ])
             ).toBe(false)
@@ -59,11 +59,14 @@ describe('supportsAudioSamplingRate', () => {
             const high = audioQuality([96_000])
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, low, 0, [low, high])
+                withinAudioSampleRateRange({ capabilities }, low, 0, [
+                    low,
+                    high,
+                ])
             ).toBe(false)
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, high, 1, [
+                withinAudioSampleRateRange({ capabilities }, high, 1, [
                     low,
                     high,
                 ])
@@ -74,7 +77,7 @@ describe('supportsAudioSamplingRate', () => {
             const metadata = audioQuality([48_000])
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, metadata, 0, [
+                withinAudioSampleRateRange({ capabilities }, metadata, 0, [
                     metadata,
                 ])
             ).toBe(true)
@@ -84,7 +87,7 @@ describe('supportsAudioSamplingRate', () => {
             const metadata = audioQuality(null)
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, metadata, 0, [
+                withinAudioSampleRateRange({ capabilities }, metadata, 0, [
                     metadata,
                 ])
             ).toBe(true)
@@ -100,7 +103,18 @@ describe('supportsAudioSamplingRate', () => {
             const metadata = audioQuality([48_000])
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, metadata, 0, [
+                withinAudioSampleRateRange({ capabilities }, metadata, 0, [
+                    metadata,
+                ])
+            ).toBe(true)
+        })
+
+        it('keeps everything when there is no platform max to gauge support', () => {
+            capabilities.sampleRate = null
+            const metadata = audioQuality([96_000])
+
+            expect(
+                withinAudioSampleRateRange({ capabilities }, metadata, 0, [
                     metadata,
                 ])
             ).toBe(true)
@@ -111,7 +125,7 @@ describe('supportsAudioSamplingRate', () => {
             const high = audioQuality([96_000])
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, high, 1, [
+                withinAudioSampleRateRange({ capabilities }, high, 1, [
                     low,
                     high,
                 ])
@@ -123,11 +137,14 @@ describe('supportsAudioSamplingRate', () => {
             const high = audioQuality([96_000])
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, low, 0, [low, high])
+                withinAudioSampleRateRange({ capabilities }, low, 0, [
+                    low,
+                    high,
+                ])
             ).toBe(true)
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, high, 1, [
+                withinAudioSampleRateRange({ capabilities }, high, 1, [
                     low,
                     high,
                 ])
@@ -142,7 +159,7 @@ describe('supportsAudioSamplingRate', () => {
 
             // Without an override, 96kHz is dropped (a 48kHz alternative exists).
             expect(
-                supportsAudioSamplingRate({ capabilities }, high, 1, [
+                withinAudioSampleRateRange({ capabilities }, high, 1, [
                     low,
                     high,
                 ])
@@ -150,7 +167,7 @@ describe('supportsAudioSamplingRate', () => {
 
             // With maxSampleRate = 96kHz, it is kept.
             expect(
-                supportsAudioSamplingRate(
+                withinAudioSampleRateRange(
                     { capabilities, maxSampleRate: 96_000 },
                     high,
                     1,
@@ -166,7 +183,7 @@ describe('supportsAudioSamplingRate', () => {
             const high = audioQuality([96_000])
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, high, 1, [
+                withinAudioSampleRateRange({ capabilities }, high, 1, [
                     low,
                     high,
                 ])
@@ -174,7 +191,7 @@ describe('supportsAudioSamplingRate', () => {
 
             // Capping at 48kHz drops the 96kHz rendition and keeps the 48kHz one.
             expect(
-                supportsAudioSamplingRate(
+                withinAudioSampleRateRange(
                     { capabilities, maxSampleRate: 48_000 },
                     high,
                     1,
@@ -182,7 +199,7 @@ describe('supportsAudioSamplingRate', () => {
                 )
             ).toBe(false)
             expect(
-                supportsAudioSamplingRate(
+                withinAudioSampleRateRange(
                     { capabilities, maxSampleRate: 48_000 },
                     low,
                     0,
@@ -202,13 +219,13 @@ describe('supportsAudioSamplingRate', () => {
             video.audioSamplingRate = null
 
             expect(
-                supportsAudioSamplingRate({ capabilities }, audio, 0, [
+                withinAudioSampleRateRange({ capabilities }, audio, 0, [
                     audio,
                     video,
                 ])
             ).toBe(true)
             expect(
-                supportsAudioSamplingRate({ capabilities }, video, 1, [
+                withinAudioSampleRateRange({ capabilities }, video, 1, [
                     audio,
                     video,
                 ])
@@ -224,5 +241,71 @@ describe('supportsAudioSamplingRate', () => {
             expect(error).toEqual(jasmine.any(Error))
             expect((error as Error).message).toBe('No supported sample rate')
         }
+    })
+})
+
+describe('withinAudioSampleRateRange minSampleRate floor', () => {
+    let capabilities: MockCapabilities
+
+    beforeEach(() => {
+        capabilities = new MockCapabilities()
+        // High enough that the upper bound never interferes with these tests.
+        capabilities.sampleRate = 192_000
+    })
+
+    function audioQuality(rate: number[] | null) {
+        const quality = createEmptyMediaQualityMetadata()
+        quality.contentType = 'audio'
+        quality.audioSamplingRate = rate
+        return quality
+    }
+
+    // minSampleRate is passed via the options arg alongside capabilities.
+    function withinMin(
+        metadata: ReturnType<typeof audioQuality>,
+        index: number,
+        array: readonly ReturnType<typeof audioQuality>[]
+    ): boolean {
+        return withinAudioSampleRateRange(
+            { capabilities, minSampleRate: 48_000 },
+            metadata,
+            index,
+            array
+        )
+    }
+
+    it('passes through non-audio qualities', () => {
+        const video = createEmptyMediaQualityMetadata()
+        video.contentType = 'video'
+        expect(withinMin(video, 0, [video])).toBe(true)
+    })
+
+    it('keeps qualities with no sampling rate', () => {
+        const quality = audioQuality(null)
+        expect(withinMin(quality, 0, [quality])).toBe(true)
+    })
+
+    it('drops rates below the floor when a rate at or above it exists', () => {
+        const low = audioQuality([24_000])
+        const high = audioQuality([48_000])
+        expect(withinMin(high, 1, [low, high])).toBe(true)
+        expect(withinMin(low, 0, [low, high])).toBe(false)
+    })
+
+    it('keeps the highest when every rate is below the floor', () => {
+        const low = audioQuality([16_000])
+        const mid = audioQuality([24_000])
+        expect(withinMin(mid, 1, [low, mid])).toBe(true)
+        expect(withinMin(low, 0, [low, mid])).toBe(false)
+    })
+
+    it('ignores non-audio qualities in the floor fallback', () => {
+        const audio = audioQuality([24_000]) // below the floor
+        const video = createEmptyMediaQualityMetadata()
+        video.contentType = 'video'
+        video.audioSamplingRate = null
+        // Below the 48kHz floor but the only audio → kept; video is ignored.
+        expect(withinMin(audio, 0, [audio, video])).toBe(true)
+        expect(withinMin(video, 1, [audio, video])).toBe(true)
     })
 })


### PR DESCRIPTION
fix(sample-rate): only gate audio content types
supportsAudioSamplingRate's "keep the lowest rate" fallback computed
allAboveMax over every quality in the period. A co-present video quality
declares no audio sampling rate, so last(null) != null was false and
allAboveMax came out false — suppressing the fallback and dropping
otherwise-playable audio whenever its rate exceeds the platform max
(e.g. standard 48kHz audio on a 44.1kHz output device, since
capabilities.sampleRate is the AudioContext output rate). The audio then
had no qualities in the timeline, so its source buffer was never created
and playback stalled on a readyToAppend timeout.

Gate only audio content types: non-audio qualities pass through, and the
keep-lowest fallback considers only audio qualities so it can no longer
be defeated by a co-present video rendition. Also document that a null
maxSampleRate (no AudioContext) keeps all rates, bypassing Firefox's
48kHz cap.