### PR TITLE
Fix/drm session reuse

### DIFF
--- a/packages/vinyl/src/drm/DrmControllerImpl.ts
+++ b/packages/vinyl/src/drm/DrmControllerImpl.ts
@@ -114,13 +114,13 @@ interface MaybeCreateSessionOptions {
  * Options for {@link DrmControllerImpl.createNewSession}.
  */
 interface CreateNewSessionOptions {
-    readonly serverCertificate: Maybe<ServerCertificate>
     readonly mediaKeys: CommonMediaKeys
+    // Already transformed (see maybeCreateSession): handed to the CDM as-is and
+    // stored as the session's reuse key.
     readonly initData: EncryptedInitData
     readonly initDataType: DrmInitDataType
     readonly drmInfo: MediaFormatMetadata & { readonly mimeType: string }
     readonly trackUri: TrackUri | null
-    readonly initDataTransformer?: InitDataTransformer | undefined
 }
 
 export class DrmControllerImpl
@@ -323,33 +323,50 @@ export class DrmControllerImpl
             licenseServerOptionsProvider ?? {}
         )
         this.abortIfDisposed()
-        const existingSession = this.getSessionByInitData(initData)
+
+        const certBytes = toCertBytes(licenseServerOptions.serverCertificate)
+        if (certBytes) {
+            await mediaKeys.setServerCertificate(certBytes)
+            this.abortIfDisposed()
+        }
+
+        // Transform the init data before matching OR creating a session, so the
+        // CDM receives — and the session stores — the transformed bytes, and the
+        // reuse check compares like-for-like. Identity for everything but
+        // FairPlay (which repacks the skd with the content ID and certificate).
+        const transform =
+            keySystemOptions?.initDataTransformer ??
+            defaultInitDataTransformer(mediaKeys.keySystem, certBytes)
+        const transformedInitData = transform(
+            bufferToByteArray(initData),
+            initDataType,
+            drmInfo
+        )
+
+        const existingSession = this.getSessionByInitData(transformedInitData)
         if (existingSession) {
             logDebug(this, 'reusing session')
             return existingSession
-        } else {
-            const newSession = await this.createNewSession({
-                serverCertificate: licenseServerOptions.serverCertificate,
-                mediaKeys,
-                initData,
-                initDataType,
-                drmInfo,
-                trackUri,
-                initDataTransformer: keySystemOptions?.initDataTransformer,
-            })
-            this.sessions.push(newSession)
-            this.dispatch('sessionCreate', {
-                initDataType: newSession.initDataType,
-                mimeType: newSession.mimeType,
-            })
-            newSession.on('closed', () => this.closeSession(newSession))
-            abort?.onAborted(() => {
-                if (this.disposed) return
-                logDebug(this, 'abort session')
-                this.closeSession(newSession)
-            })
-            return newSession
         }
+        const newSession = this.createNewSession({
+            mediaKeys,
+            initData: transformedInitData,
+            initDataType,
+            drmInfo,
+            trackUri,
+        })
+        this.sessions.push(newSession)
+        this.dispatch('sessionCreate', {
+            initDataType: newSession.initDataType,
+            mimeType: newSession.mimeType,
+        })
+        newSession.on('closed', () => this.closeSession(newSession))
+        abort?.onAborted(() => {
+            if (this.disposed) return
+            logDebug(this, 'abort session')
+            this.closeSession(newSession)
+        })
+        return newSession
     }
 
     initializeForPlayback(
@@ -533,39 +550,13 @@ export class DrmControllerImpl
     /**
      * Creates a new key session and adds a message handler.
      */
-    private async createNewSession(
+    private createNewSession(
         options: CreateNewSessionOptions
-    ): Promise<CommonMediaKeySession> {
-        const {
-            serverCertificate,
-            mediaKeys,
-            initDataType,
-            drmInfo,
-            trackUri,
-            initDataTransformer,
-        } = options
-        let initData = options.initData
-        const certBytes = serverCertificate
-            ? typeof serverCertificate === 'string'
-                ? base64ToByteArray(serverCertificate)
-                : bufferToByteArray(serverCertificate)
-            : null
-
-        if (certBytes) {
-            await mediaKeys.setServerCertificate(certBytes)
-        }
-
-        // Default initDataTransformer handles FAIR_PLAY_1_0 by packing the
-        // skd init data with the content ID and server certificate.
-        // FAIR_PLAY_1_0 always uses initDataType 'skd', so the default
-        // does not need to explicitly check initDataType.
-        const transform =
-            initDataTransformer ??
-            defaultInitDataTransformer(mediaKeys.keySystem, certBytes)
-        initData = transform(bufferToByteArray(initData), initDataType, drmInfo)
+    ): CommonMediaKeySession {
+        const { mediaKeys, initData, initDataType, drmInfo, trackUri } = options
 
         this.abortIfDisposed()
-        logDebug(this, 'createSession', drmInfo.mimeType, initDataType)
+        logDebug(this, 'createSession', drmInfo.mimeType, initDataType, drmInfo)
         const session = mediaKeys.createSession(
             drmInfo.mimeType,
             initDataType,
@@ -756,9 +747,9 @@ export class DrmControllerImpl
         initData: EncryptedInitData
     ): CommonMediaKeySession | null {
         return (
-            this.sessions.find((session) => {
-                return buffersEqual(session.initData, initData)
-            }) ?? null
+            this.sessions.find((session) =>
+                buffersEqual(session.initData, initData)
+            ) ?? null
         )
     }
 
@@ -791,6 +782,15 @@ function hasMimeType(
     drmInfo: MediaFormatMetadata
 ): drmInfo is MediaFormatMetadata & { readonly mimeType: string } {
     return drmInfo.mimeType != null
+}
+
+function toCertBytes(
+    serverCertificate: Maybe<ServerCertificate>
+): Uint8Array<ArrayBuffer> | null {
+    if (!serverCertificate) return null
+    return typeof serverCertificate === 'string'
+        ? base64ToByteArray(serverCertificate)
+        : bufferToByteArray(serverCertificate)
 }
 
 /**

--- a/packages/vinyl/src/drm/DrmControllerImpl.ts
+++ b/packages/vinyl/src/drm/DrmControllerImpl.ts
@@ -115,8 +115,7 @@ interface MaybeCreateSessionOptions {
  */
 interface CreateNewSessionOptions {
     readonly mediaKeys: CommonMediaKeys
-    // Already transformed (see maybeCreateSession): handed to the CDM as-is and
-    // stored as the session's reuse key.
+    // Already transformed (see maybeCreateSession).
     readonly initData: EncryptedInitData
     readonly initDataType: DrmInitDataType
     readonly drmInfo: MediaFormatMetadata & { readonly mimeType: string }
@@ -236,6 +235,11 @@ export class DrmControllerImpl
         event: CommonMediaEncryptedEvent
     ) => {
         if (this.disposed) return
+        // Manifest pssh drives sessions; ignore redundant in-band events.
+        if (this.manifestProvidesInitData()) {
+            logDebug(this, 'ignoring encrypted event; manifest provides pssh')
+            return
+        }
         ;(async () => {
             const { initData, initDataType } = event
             if (!initData) {
@@ -330,10 +334,8 @@ export class DrmControllerImpl
             this.abortIfDisposed()
         }
 
-        // Transform the init data before matching OR creating a session, so the
-        // CDM receives — and the session stores — the transformed bytes, and the
-        // reuse check compares like-for-like. Identity for everything but
-        // FairPlay (which repacks the skd with the content ID and certificate).
+        // Transform before matching/creating so the reuse check compares the
+        // same (transformed) bytes the CDM gets. Identity except FairPlay.
         const transform =
             keySystemOptions?.initDataTransformer ??
             defaultInitDataTransformer(mediaKeys.keySystem, certBytes)
@@ -381,6 +383,14 @@ export class DrmControllerImpl
                 options?.abort
             ).catch(this.handleError)
         }
+    }
+
+    /** True when the manifest carried pssh (sessions come from it, not events). */
+    private manifestProvidesInitData(): boolean {
+        return (
+            this.drmInfo?.contentProtections.some((cP) => cP.pssh != null) ??
+            false
+        )
     }
 
     setBufferingDrmInfo(

--- a/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
@@ -515,6 +515,48 @@ describe('DrmControllerImpl', () => {
             expect(mediaKeys.createSession).toHaveBeenCalledTimes(1) // reused
         })
 
+        it('reuses the session when a transformer alters the CDM init data', async () => {
+            // A non-identity initDataTransformer changes the bytes handed to the
+            // CDM (always the case for FairPlay, or any custom transformer). The
+            // reuse check must compare the ORIGINAL init data, not the
+            // transformed bytes — otherwise every re-appended init segment fires
+            // `encrypted` and spins up a brand-new session instead of recycling.
+            const transformed = new Uint8Array([9, 9, 9])
+            const controller = new DrmControllerImpl(deps, {
+                licenseProvider,
+                keySystems: {
+                    [DrmKeySystem.WIDEVINE]: {
+                        initDataTransformer: () => transformed,
+                    },
+                },
+            })
+            const localErrors = createEventSpy(controller, 'error')
+            const encryptedCb =
+                commonEme.addEncryptedListener.calls.mostRecent().args[1]
+            controller.setBufferingDrmInfo(drmInfo)
+
+            encryptedCb({
+                initData: new Uint8Array([1, 2, 3]),
+                initDataType: 'cenc',
+            })
+            await flushPromises()
+            expect(mediaKeys.createSession).toHaveBeenCalledTimes(1)
+            // The session stored the transformed bytes handed to the CDM.
+            expect(getSession(0).initData).toEqual(transformed)
+
+            // The same raw init data fires again (e.g. a quality switch
+            // re-appends the init segment) — the session must be reused.
+            encryptedCb({
+                initData: new Uint8Array([1, 2, 3]),
+                initDataType: 'cenc',
+            })
+            await flushPromises()
+            expect(localErrors).not.toHaveBeenCalled()
+            expect(mediaKeys.createSession).toHaveBeenCalledTimes(1) // reused
+
+            controller.dispose()
+        })
+
         describe('and the drm controller is disposed', () => {
             it('does nothing', async () => {
                 drmController.dispose()

--- a/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
@@ -557,6 +557,23 @@ describe('DrmControllerImpl', () => {
             controller.dispose()
         })
 
+        it('ignores encrypted events when the manifest supplies pssh', async () => {
+            // The proactive manifest-pssh path owns session creation, so in-band
+            // `encrypted` events (e.g. a re-appended init segment on an ABR
+            // switch) must not spawn a duplicate session.
+            const drmInfoWithPssh = {
+                ...drmInfo,
+                contentProtections: [
+                    { keySystem: DrmKeySystem.WIDEVINE, pssh: 'AAAA' },
+                ],
+            } as const satisfies MediaFormatMetadata
+            drmController.setBufferingDrmInfo(drmInfoWithPssh)
+
+            await emitEncrypted(new Uint8Array([1, 2, 3]))
+            expect(errorSpy).not.toHaveBeenCalled()
+            expect(mediaKeys.createSession).not.toHaveBeenCalled()
+        })
+
         describe('and the drm controller is disposed', () => {
             it('does nothing', async () => {
                 drmController.dispose()


### PR DESCRIPTION
fix(drm): ignore encrypted events when the manifest supplies pssh

Content whose manifest carries pssh created sessions proactively from
that pssh (createSessionFromInitData), then ALSO created sessions from
the in-band `encrypted` events — whose init data (the segment's full
cenc pssh boxes) never byte-matches the manifest pssh, so a re-appended
init segment on an ABR switch spawned duplicate key sessions (plus a
race between concurrent encrypted events).

Suppress `encrypted` events when the manifest provides pssh, letting the
proactive path own session creation. Mirrors Shaka.