### PR TITLE
test(ad): dispose controllers after each spec to stop async log leak

### DIFF
--- a/packages/vinyl/test/unit/ad/AdControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/ad/AdControllerImpl.test.ts
@@ -10,13 +10,23 @@ import type { MaybePromise } from '@amazon/vinyl-util'
 
 describe('AdControllerImpl', () => {
     let playbackController: MockPlaybackController
+    let controllers: AdControllerImpl[]
 
     beforeEach(() => {
         playbackController = new MockPlaybackController()
+        controllers = []
+    })
+
+    // Dispose every controller a spec created. An activated-but-unstarted ad
+    // arms a `sleep(adLoadTimeout)` timer.
+    afterEach(() => {
+        for (const c of controllers) if (!c.disposed) c.dispose()
     })
 
     function createController() {
-        return new AdControllerImpl({ playbackController })
+        const c = new AdControllerImpl({ playbackController })
+        controllers.push(c)
+        return c
     }
 
     function updateTime(time: number) {


### PR DESCRIPTION
AdControllerImpl specs created controllers via createController() but never disposed them. An activated-but-unstarted ad arms a sleep(adLoadTimeout) timer whose callback runs failAd -> completeAd -> logDebug; when the timer fired during a LATER spec it initialized the global loggerRef after teardown, so the next loggerRef.set() threw "Cannot call when initialized" and surfaced on an unrelated spec (e.g. SegmentControllerImpl) as a flaky failure.

Track every controller and dispose it in afterEach so the pending timer/promise callbacks no-op via their existing `disposed` guards.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
