### PR TITLE
feat(website): add GoatCounter analytics

### DIFF
--- a/packages/vinyl-website/buildSrc/pageTemplate.ts
+++ b/packages/vinyl-website/buildSrc/pageTemplate.ts
@@ -73,6 +73,10 @@ export interface PageMeta {
     readonly jsonLd?: object | readonly object[]
 }
 
+/** GoatCounter analytics; loaded async on every page. */
+const ANALYTICS_SCRIPT =
+    '<script data-goatcounter="https://vinyl.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>'
+
 /** Renders the per-page `<head>` SEO block that fills the `ssg:head` marker. */
 export function renderHeadMeta(meta: PageMeta): string {
     const canonical = absoluteUrl(meta.canonicalPath ?? meta.path)
@@ -102,6 +106,7 @@ export function renderHeadMeta(meta: PageMeta): string {
         `<meta name="twitter:description" content="${escapeHtml(meta.description)}" />`,
         `<meta name="twitter:image" content="${escapeHtml(image)}" />`,
         jsonLd,
+        ANALYTICS_SCRIPT,
     ]
         .filter(Boolean)
         .join('\n        ')


### PR DESCRIPTION
Inject the GoatCounter count.js snippet (async) into every page's <head> via renderHeadMeta.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
