### PR TITLE
test(audio): pin non-Firefox UA for the maxSampleRate transformer test

### DIFF
--- a/packages/vinyl/test/unit/streaming/createDefaultMediaTimelineTransformer.test.ts
+++ b/packages/vinyl/test/unit/streaming/createDefaultMediaTimelineTransformer.test.ts
@@ -11,6 +11,7 @@ import {
     type MediaTimeline,
 } from '@amazon/vinyl'
 import { data } from '@amazon/vinyl-observable'
+import { setUserAgent } from '@amazon/vinyl-util'
 import {
     MockCapabilities,
     MockDrmController,
@@ -453,6 +454,8 @@ describe('createDefaultMediaTimelineTransformer', () => {
     })
 
     it('honors audio.maxSampleRate over the reported rate at runtime', async () => {
+        // Non-Firefox: Firefox hard-caps at 48kHz regardless of maxSampleRate.
+        setUserAgent('Chrome')
         // AudioContext reports 48kHz, so the 96kHz rendition is dropped.
         capabilities.sampleRate = 48_000
         const timeline: MediaTimeline = {


### PR DESCRIPTION
Firefox hard-caps audio at 48kHz regardless of maxSampleRate, so the "maxSampleRate raises the cap to keep 96kHz" assertion only holds off Firefox. The test didn't set a user agent, so it failed when the integ bundle ran it under Firefox. Pin the UA to Chrome (reset per-spec by the global registry reset in setup).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
