### PR TITLE
fix(mse): don't double hard-reset on allowedContentTypes change

### DIFF
--- a/packages/vinyl/src/track/mse/MseTrack.ts
+++ b/packages/vinyl/src/track/mse/MseTrack.ts
@@ -197,11 +197,6 @@ export class MseTrack extends TrackBase {
                 if (previous !== undefined) this.reloadStreams()
             })
         )
-        add(
-            deps.allowedContentTypes.onData((_value, previous) => {
-                if (previous !== undefined) this.reloadStreams()
-            })
-        )
         // A resolution-restriction change re-selects a quality from the same
         // streams, so clearing the buffer is enough — no rebuild is needed.
         add(

--- a/packages/vinyl/test/unit/streaming/MseTrack.test.ts
+++ b/packages/vinyl/test/unit/streaming/MseTrack.test.ts
@@ -1274,10 +1274,6 @@ describe('MseTrack', () => {
                 apply: () => (deps.audio.value = jaAudio),
             },
             {
-                name: 'allowedContentTypes',
-                apply: () => (deps.allowedContentTypes.value = allowed),
-            },
-            {
                 name: 'audio descriptive',
                 apply: () => (deps.audio.value = descriptiveAudio),
             },
@@ -1302,6 +1298,19 @@ describe('MseTrack', () => {
                 })
             })
         }
+
+        describe('when allowedContentTypes changes', () => {
+            // It only affects the content-type set, which flows through
+            // contentTypesValue -> setContentTypes. Reloading directly here too
+            // would double hard-reset and seek to 0.
+            it('does not reload directly', () => {
+                const clearSpy = spyOn(track!, 'clearPrefetch')
+                const resetSpy = spyOn(track!, 'reset')
+                deps.allowedContentTypes.value = allowed
+                expect(clearSpy).not.toHaveBeenCalled()
+                expect(resetSpy).not.toHaveBeenCalled()
+            })
+        })
 
         describe('when abr resolution restrictions change', () => {
             it('clears prefetch (without a rebuild) when maxHeight changes', () => {


### PR DESCRIPTION
allowedContentTypes only affects the content-type set, which already flows through contentTypesValue -> setContentTypes (which hard-resets and rebuilds streams when the set changes). MseTrack ALSO subscribed to allowedContentTypes directly to reloadStreams, so a change fired two hard resets: the first tore down the media source (currentTime -> 0) and issued a restore seek that awaits loadedMetadata; the second then captured the now-0 currentTime and seeked to 0, superseding the restore.

Drop the redundant direct subscription; the contentTypesValue path is the single driver, so one reset restores the position.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
