### PR TITLE
fix(playback): drive stuck end-of-track to ended on progressive tracks

### DIFF
--- a/packages/vinyl/src/playback/createStallDetector.ts
+++ b/packages/vinyl/src/playback/createStallDetector.ts
@@ -114,15 +114,28 @@ export function createStallDetector(
     return stop
 }
 
-/** True when the play head sits inside a buffered range, clear of its end by {@link endMargin}. */
+/**
+ * True when the play head sits inside a buffered range, clear of its end by
+ * {@link endMargin} — i.e. there is data to keep playing.
+ *
+ * A range that ends at the end of the media is treated as nudgeable up to its
+ * end: no more data is coming, so a freeze there is a stuck end-of-track (seen
+ * on progressive `src` tracks), and a nudge pushes the element to `ended`.
+ */
 function withinBufferedData(
     media: HTMLMediaElement,
     endMargin: number
 ): boolean {
     const t = media.currentTime
+    const duration = media.duration
     const buffered = media.buffered
     for (let i = 0; i < buffered.length; i++) {
-        if (t >= buffered.start(i) && t < buffered.end(i) - endMargin)
+        const end = buffered.end(i)
+        const isEndOfMedia =
+            Number.isFinite(duration) &&
+            duration > 0 &&
+            end >= duration - endMargin
+        if (t >= buffered.start(i) && (t < end - endMargin || isEndOfMedia))
             return true
     }
     return false

--- a/packages/vinyl/test/unit/playback/createStallDetector.test.ts
+++ b/packages/vinyl/test/unit/playback/createStallDetector.test.ts
@@ -97,6 +97,16 @@ describe('createStallDetector', () => {
             expect(media.currentTime).toBe(10)
         })
 
+        it('nudges at the end of the media (stuck end-of-track on src)', async () => {
+            // Buffer ends at the media duration: no more data is coming, so a
+            // freeze here is a stuck end-of-track and a nudge drives it to end.
+            media.buffered = new MockTimeRanges([[0, 10.3]])
+            media.duration = 10.3
+            detect()
+            await poll(3)
+            expect(media.currentTime).toBeCloseTo(10.1)
+        })
+
         it('nudges outside buffered ranges when nudgeUnbuffered is set', async () => {
             // WebKit path: re-issue the seek even though buffered looks empty.
             media.buffered = new MockTimeRanges([[50, 100]])


### PR DESCRIPTION
The stall detector treated a playhead frozen near the end of buffered data as a legitimate wait for more data and never nudged it. On progressive (src) tracks the buffer ends at the media duration, so no more data is coming and 'ended' never fires. Treat a freeze within the end margin of a finite, positive duration as a stuck end-of-track and nudge it to completion.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
