### PR TITLE
Feature/loadspan drm observability

### DIFF
--- a/packages/vinyl/src/drm/DrmControllerImpl.ts
+++ b/packages/vinyl/src/drm/DrmControllerImpl.ts
@@ -27,6 +27,7 @@ import {
     type ReadonlyAbort,
     remove,
     resolveValueProvider,
+    type Timestamp,
     withTimeout,
 } from '@amazon/vinyl-util'
 import { instanceOf, object, type ObjectSchema } from '@amazon/vinyl-validation'
@@ -67,6 +68,7 @@ import { defaultLicenseProvider } from './licenseProvider/defaultLicenseProvider
 import { extractContentId } from './util/extractContentId'
 import { createFairPlaySessionInitData } from './util/createFairPlaySessionInitData'
 import type { TrackUri } from '../track/Track'
+import type { LoadSpanKind } from '../streaming/LoadMetric'
 
 /**
  * The number of seconds a license request will be allowed before timing out.
@@ -150,6 +152,12 @@ export class DrmControllerImpl
     private sessionAbort: ReadonlyAbort | null = null
 
     private pendingMessageProps: DrmControllerMessageProps | null = null
+
+    // Armed per track load; latches on the first session so only the
+    // critical-path session's EME/CDM setup is measured.
+    private keySetupSpanArmed = true
+    private keySetupSpanStart: Timestamp | null = null
+
     private readonly disposer = createDisposer()
 
     constructor(
@@ -322,6 +330,7 @@ export class DrmControllerImpl
             throw new DrmError('Encrypted content must have a mimeType.')
         }
 
+        this.markKeySetupStart()
         const mediaKeys = await this.attachMediaKeys(drmInfo)
         this.abortIfDisposed()
 
@@ -378,6 +387,39 @@ export class DrmControllerImpl
         return newSession
     }
 
+    /**
+     * Captures the key-setup span start at the top of the session-creation path
+     * (before media keys are attached), latching so only the first session of
+     * the current track load is measured.
+     */
+    private markKeySetupStart(): void {
+        if (!this.keySetupSpanArmed) return
+        this.keySetupSpanArmed = false
+        this.keySetupSpanStart = Date.now()
+    }
+
+    private dispatchLoadSpan(
+        kind: LoadSpanKind,
+        startTime: Timestamp,
+        endTime: Timestamp,
+        messageProps: DrmControllerMessageProps
+    ): void {
+        this.dispatch('loadSpanMeasured', {
+            kind,
+            startTime,
+            endTime,
+            mimeType: messageProps.mimeType,
+            // Attributed at the source to the session's track; omitted (not set
+            // to undefined) when unknown, per exactOptionalPropertyTypes.
+            ...(messageProps.trackUri != null && {
+                trackUri: messageProps.trackUri,
+            }),
+            ...(messageProps.contentType != null && {
+                contentType: messageProps.contentType,
+            }),
+        })
+    }
+
     initializeForPlayback(
         drmInfo: MediaFormatMetadata | null,
         options?: DrmPlaybackOptions
@@ -410,6 +452,9 @@ export class DrmControllerImpl
         this.drmInfo = drmInfo
         this.bufferingTrackUri = options?.trackUri ?? null
         this.sessionAbort = options?.abort ?? null
+        // Re-arm so the new track load's first session is measured.
+        this.keySetupSpanArmed = true
+        this.keySetupSpanStart = null
     }
 
     /**
@@ -425,6 +470,7 @@ export class DrmControllerImpl
             this.handleError(new DrmError('DRM not supported.'))
             return
         }
+        this.markKeySetupStart()
         const mediaKeys = await this.attachMediaKeys(drmInfo)
         const drmProtection =
             drmInfo.contentProtections.find((cP) => {
@@ -615,6 +661,18 @@ export class DrmControllerImpl
         const keySystem = mediaKeys.keySystem
         logDebug(this, 'message', keySystem, event.message.byteLength)
 
+        // The CDM's first message ends the setup span; it is contiguous with the
+        // license round-trip measured below.
+        if (this.keySetupSpanStart != null) {
+            this.dispatchLoadSpan(
+                'keySetup',
+                this.keySetupSpanStart,
+                Date.now(),
+                messageProps
+            )
+            this.keySetupSpanStart = null
+        }
+
         const keySystemOptions =
             this.options.keySystems[keySystem] ?? this.options.keySystems['*']
         const licenseServerOptionsProvider = keySystemOptions?.licenseServer
@@ -645,20 +703,12 @@ export class DrmControllerImpl
             challenge
         )
         if (this.disposed) return
-        this.dispatch('loadSpanMeasured', {
-            kind: 'license',
-            startTime: licenseSpanStart,
-            endTime: Date.now(),
-            mimeType: messageProps.mimeType,
-            // Attributed at the source to the session's track; omitted (not set
-            // to undefined) when unknown, per exactOptionalPropertyTypes.
-            ...(messageProps.trackUri != null && {
-                trackUri: messageProps.trackUri,
-            }),
-            ...(messageProps.contentType != null && {
-                contentType: messageProps.contentType,
-            }),
-        })
+        this.dispatchLoadSpan(
+            'license',
+            licenseSpanStart,
+            Date.now(),
+            messageProps
+        )
         this.pendingMessageProps = null
         if (session.disposed) return
         logDebug(this, 'update')

--- a/packages/vinyl/src/drm/DrmControllerImpl.ts
+++ b/packages/vinyl/src/drm/DrmControllerImpl.ts
@@ -97,6 +97,13 @@ export interface DrmControllerMessageProps {
      * to their own track.
      */
     readonly trackUri: TrackUri | null
+    /**
+     * The MIME and content type of the session's content, captured at creation
+     * so the license span can distinguish the certificate exchange from the
+     * per-content-type license exchanges.
+     */
+    readonly mimeType: string
+    readonly contentType: ContentType | null
 }
 
 /**
@@ -581,6 +588,8 @@ export class DrmControllerImpl
                     // Captured per session, so a concurrent preloaded track's
                     // license exchange keeps its own attribution.
                     trackUri: trackUri,
+                    mimeType: drmInfo.mimeType,
+                    contentType: drmInfo.contentType,
                 }),
                 LICENSE_TIMEOUT,
                 { message: LICENSE_TIMEOUT_MESSAGE }
@@ -640,10 +649,14 @@ export class DrmControllerImpl
             kind: 'license',
             startTime: licenseSpanStart,
             endTime: Date.now(),
+            mimeType: messageProps.mimeType,
             // Attributed at the source to the session's track; omitted (not set
             // to undefined) when unknown, per exactOptionalPropertyTypes.
             ...(messageProps.trackUri != null && {
                 trackUri: messageProps.trackUri,
+            }),
+            ...(messageProps.contentType != null && {
+                contentType: messageProps.contentType,
             }),
         })
         this.pendingMessageProps = null

--- a/packages/vinyl/src/streaming/LoadMetric.ts
+++ b/packages/vinyl/src/streaming/LoadMetric.ts
@@ -5,6 +5,7 @@
 
 import type { Timestamp } from '@amazon/vinyl-util'
 import type { TrackUri } from '../track/Track'
+import type { ContentType } from './MediaQualityMetadata'
 
 /**
  * The stage of the track-load journey a {@link LoadSpanMeasurement} describes.
@@ -46,6 +47,19 @@ export interface LoadSpanMeasurement {
      * buffering DRM info is set).
      */
     readonly trackUri?: TrackUri
+
+    /**
+     * The MIME type of the content this span was measured for, when known. Set
+     * for DRM `license` spans so a certificate exchange and the per-content-type
+     * license exchanges are distinguishable.
+     */
+    readonly mimeType?: string
+
+    /**
+     * The content type this span was measured for, when known. Set alongside
+     * {@link mimeType} for DRM `license` spans.
+     */
+    readonly contentType?: ContentType
 }
 
 /**

--- a/packages/vinyl/src/streaming/LoadMetric.ts
+++ b/packages/vinyl/src/streaming/LoadMetric.ts
@@ -11,12 +11,14 @@ import type { ContentType } from './MediaQualityMetadata'
  * The stage of the track-load journey a {@link LoadSpanMeasurement} describes.
  *
  * - `manifest`: fetching and parsing the DASH/HLS manifest.
+ * - `keySetup`: the EME/CDM setup, from session creation to the CDM's first
+ *   license message. Precedes and is contiguous with `license`.
  * - `license`: the DRM license request/response exchange.
  * - `initSegment`: fetching the initialization segment.
  * - `firstSegment`: fetching the first media segment.
  */
 export type LoadSpanKind =
-    'manifest' | 'license' | 'initSegment' | 'firstSegment'
+    'manifest' | 'keySetup' | 'license' | 'initSegment' | 'firstSegment'
 
 /**
  * A timed span for one stage of a track load.

--- a/packages/vinyl/src/vinyl/VinylPlayer.ts
+++ b/packages/vinyl/src/vinyl/VinylPlayer.ts
@@ -11,8 +11,11 @@ import {
     emptyRanges,
     equalDeep,
     EventHostImpl,
+    getLogLevel,
     logDebug,
     logInfo,
+    LogLevel,
+    logVerbose,
     logWarn,
     type ReadonlyRanges,
     type ReadonlySet,
@@ -174,7 +177,29 @@ export class VinylPlayer<
         playerRegistryRef.value.addPlayer(this)
         this.redispatchSubControllerEvents()
         this.redispatchCurrentTrackEvents()
+        this.initializeLoadSpanLogging()
         this.initializeAutoResetHandling()
+    }
+
+    /**
+     * Logs each republished load span once at the verbose level, formatting its
+     * bounds as ISO date strings and its duration in milliseconds.
+     */
+    protected initializeLoadSpanLogging(): void {
+        this.disposer.add(
+            this.on('loadSpan', (span) => {
+                // logVerbose would drop the record when verbose is off, but the
+                // date/duration formatting below would still run; guard it.
+                if (getLogLevel() > LogLevel.VERBOSE) return
+                logVerbose(this, 'loadSpan', {
+                    kind: span.kind,
+                    trackUri: span.trackUri,
+                    startTime: new Date(span.startTime).toISOString(),
+                    endTime: new Date(span.endTime).toISOString(),
+                    durationMs: (span.endTime - span.startTime).toFixed(2),
+                })
+            })
+        )
     }
 
     protected redispatchSubControllerEvents(): void {

--- a/packages/vinyl/src/vinyl/VinylPlayer.ts
+++ b/packages/vinyl/src/vinyl/VinylPlayer.ts
@@ -194,6 +194,8 @@ export class VinylPlayer<
                 logVerbose(this, 'loadSpan', {
                     kind: span.kind,
                     trackUri: span.trackUri,
+                    mimeType: span.mimeType,
+                    contentType: span.contentType,
                     startTime: new Date(span.startTime).toISOString(),
                     endTime: new Date(span.endTime).toISOString(),
                     durationMs: (span.endTime - span.startTime).toFixed(2),

--- a/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
@@ -1208,6 +1208,21 @@ describe('DrmControllerImpl', () => {
             )
         })
 
+        it('carries the content mime and content type on the license span', async () => {
+            licenseProvider.and.resolveTo(new Uint8Array([1]).buffer)
+            const spy = createEventSpy(drmController, 'loadSpanMeasured')
+            drmController.setBufferingDrmInfo(drmInfo)
+            await emitEncrypted(new Uint8Array([1, 2, 3]), 'cenc')
+            await emitMessage(0, new ArrayBuffer(1))
+            expect(spy).toHaveBeenCalledOnceWith(
+                objectContaining({
+                    kind: 'license',
+                    mimeType: 'audio/mp4',
+                    contentType: 'audio',
+                })
+            )
+        })
+
         it('does not measure a failed license exchange', async () => {
             licenseProvider.and.rejectWith(new Error('license failed'))
             const spy = createEventSpy(drmController, 'loadSpanMeasured')

--- a/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
+++ b/packages/vinyl/test/unit/drm/DrmControllerImpl.test.ts
@@ -1199,7 +1199,7 @@ describe('DrmControllerImpl', () => {
             drmController.setBufferingDrmInfo(drmInfo)
             await emitEncrypted(new Uint8Array([1, 2, 3]), 'cenc')
             await emitMessage(0, new ArrayBuffer(1))
-            expect(spy).toHaveBeenCalledOnceWith(
+            expect(spy).toHaveBeenCalledWith(
                 objectContaining({
                     kind: 'license',
                     startTime: any(Number),
@@ -1208,13 +1208,29 @@ describe('DrmControllerImpl', () => {
             )
         })
 
+        it('measures the key setup, contiguous with and before the license', async () => {
+            licenseProvider.and.resolveTo(new Uint8Array([1]).buffer)
+            const spy = createEventSpy(drmController, 'loadSpanMeasured')
+            drmController.setBufferingDrmInfo(drmInfo, { trackUri: 'track-a' })
+            await emitEncrypted(new Uint8Array([1, 2, 3]), 'cenc')
+            await emitMessage(0, new ArrayBuffer(1))
+            const spans = spy.calls.all().map((call) => call.args[0])
+            expect(spans.map((span) => span.kind)).toEqual([
+                'keySetup',
+                'license',
+            ])
+            const [keySetup, license] = spans
+            expect(keySetup.trackUri).toEqual('track-a')
+            expect(keySetup.endTime).toEqual(license.startTime)
+        })
+
         it('carries the content mime and content type on the license span', async () => {
             licenseProvider.and.resolveTo(new Uint8Array([1]).buffer)
             const spy = createEventSpy(drmController, 'loadSpanMeasured')
             drmController.setBufferingDrmInfo(drmInfo)
             await emitEncrypted(new Uint8Array([1, 2, 3]), 'cenc')
             await emitMessage(0, new ArrayBuffer(1))
-            expect(spy).toHaveBeenCalledOnceWith(
+            expect(spy).toHaveBeenCalledWith(
                 objectContaining({
                     kind: 'license',
                     mimeType: 'audio/mp4',
@@ -1229,8 +1245,26 @@ describe('DrmControllerImpl', () => {
             drmController.setBufferingDrmInfo(drmInfo)
             await emitEncrypted(new Uint8Array([1, 2, 3]), 'cenc')
             await emitMessage(0, new ArrayBuffer(1))
-            expect(spy).not.toHaveBeenCalled()
+            // Setup completed at the message, so keySetup is still measured.
+            expect(spy).not.toHaveBeenCalledWith(
+                objectContaining({ kind: 'license' })
+            )
             errorSpy.calls.reset()
+        })
+
+        it('measures key setup only for the first session of a track load', async () => {
+            licenseProvider.and.resolveTo(new Uint8Array([1]).buffer)
+            const spy = createEventSpy(drmController, 'loadSpanMeasured')
+            drmController.setBufferingDrmInfo(drmInfo, { trackUri: 'track-a' })
+            await emitEncrypted(new Uint8Array([1]), 'cenc')
+            await emitEncrypted(new Uint8Array([2]), 'cenc')
+            expect(mediaKeys.createSession).toHaveBeenCalledTimes(2)
+            await emitMessage(0, new ArrayBuffer(1))
+            await emitMessage(1, new ArrayBuffer(1))
+            const keySetupSpans = spy.calls
+                .all()
+                .filter((call) => call.args[0].kind === 'keySetup')
+            expect(keySetupSpans.length).toEqual(1)
         })
 
         it('attributes the license span to the buffering track uri', async () => {
@@ -1239,7 +1273,7 @@ describe('DrmControllerImpl', () => {
             drmController.setBufferingDrmInfo(drmInfo, { trackUri: 'track-a' })
             await emitEncrypted(new Uint8Array([1, 2, 3]), 'cenc')
             await emitMessage(0, new ArrayBuffer(1))
-            expect(spy).toHaveBeenCalledOnceWith(
+            expect(spy).toHaveBeenCalledWith(
                 objectContaining({
                     kind: 'license',
                     trackUri: 'track-a',
@@ -1282,16 +1316,14 @@ describe('DrmControllerImpl', () => {
             await emitMessage(1, new ArrayBuffer(1))
             await emitMessage(0, new ArrayBuffer(1))
 
-            expect(spy).toHaveBeenCalledTimes(2)
-            expect(spy).toHaveBeenCalledWith(
-                objectContaining({
-                    kind: 'license',
-                    trackUri: 'track-preloaded',
-                })
-            )
-            expect(spy).toHaveBeenCalledWith(
-                objectContaining({ kind: 'license', trackUri: 'track-active' })
-            )
+            const licenseTrackUris = spy.calls
+                .all()
+                .map((call) => call.args[0])
+                .filter((span) => span.kind === 'license')
+                .map((span) => span.trackUri)
+            expect(licenseTrackUris.length).toEqual(2)
+            expect(licenseTrackUris).toContain('track-preloaded')
+            expect(licenseTrackUris).toContain('track-active')
         })
     })
 

--- a/packages/vinyl/test/unit/vinyl/VinylPlayer.test.ts
+++ b/packages/vinyl/test/unit/vinyl/VinylPlayer.test.ts
@@ -29,6 +29,7 @@ import {
     createArrayLikeIterator,
     emptyRanges,
     historyLogHandler,
+    LogLevel,
     noop,
     RangesImpl,
 } from '@amazon/vinyl-util'
@@ -49,7 +50,7 @@ import {
     MockTrackFactory,
     type MockVinylDependencies,
 } from '@amazon/vinyl/vinylTestUtil'
-import { createEventSpy } from '@amazon/vinyl-util/testUtil'
+import { createEventSpy, useMockLogger } from '@amazon/vinyl-util/testUtil'
 import { data } from '@amazon/vinyl-observable'
 import any = jasmine.any
 import createSpy = jasmine.createSpy
@@ -59,6 +60,8 @@ describe('VinylPlayer', () => {
     let depFactories: Factories<VinylDeps>
     let player: VinylPlayer
     let mockOptions: VinylDependencyOptions
+
+    const loggerRef = useMockLogger()
 
     polyfillCustomEvent()
 
@@ -335,6 +338,38 @@ describe('VinylPlayer', () => {
                 endTime: 2,
             })
             expect(spy).not.toHaveBeenCalled()
+        })
+
+        it('logs each republished span at the verbose level with formatted times', () => {
+            loggerRef.value.logLevel = LogLevel.VERBOSE
+            deps.drmController.dispatch('loadSpanMeasured', {
+                kind: 'license',
+                startTime: 1000,
+                endTime: 3500,
+                trackUri: 'track-a',
+            })
+            expect(loggerRef.value.verbose).toHaveBeenCalledOnceWith(
+                player,
+                'loadSpan',
+                {
+                    kind: 'license',
+                    trackUri: 'track-a',
+                    startTime: new Date(1000).toISOString(),
+                    endTime: new Date(3500).toISOString(),
+                    durationMs: '2500.00',
+                }
+            )
+        })
+
+        it('does not format or log a span when the verbose level is off', () => {
+            loggerRef.value.logLevel = LogLevel.DEBUG
+            deps.drmController.dispatch('loadSpanMeasured', {
+                kind: 'license',
+                startTime: 1000,
+                endTime: 3500,
+                trackUri: 'track-a',
+            })
+            expect(loggerRef.value.verbose).not.toHaveBeenCalled()
         })
     })
 

--- a/packages/vinyl/test/unit/vinyl/VinylPlayer.test.ts
+++ b/packages/vinyl/test/unit/vinyl/VinylPlayer.test.ts
@@ -347,6 +347,8 @@ describe('VinylPlayer', () => {
                 startTime: 1000,
                 endTime: 3500,
                 trackUri: 'track-a',
+                mimeType: 'audio/mp4',
+                contentType: 'audio',
             })
             expect(loggerRef.value.verbose).toHaveBeenCalledOnceWith(
                 player,
@@ -354,6 +356,8 @@ describe('VinylPlayer', () => {
                 {
                     kind: 'license',
                     trackUri: 'track-a',
+                    mimeType: 'audio/mp4',
+                    contentType: 'audio',
                     startTime: new Date(1000).toISOString(),
                     endTime: new Date(3500).toISOString(),
                     durationMs: '2500.00',


### PR DESCRIPTION
feat(streaming): tag DRM license load spans with mime and content type
Add optional mimeType/contentType to LoadSpanMeasurement and thread them from
the session's drmInfo at the license loadSpanMeasured dispatch, so a
certificate exchange and the per-content-type license exchanges are
distinguishable.