### PR TITLE
Fix/vinyl audio strand readytoappend

### DIFF
--- a/packages/vinyl/src/streaming/mediaTimelineFilter.ts
+++ b/packages/vinyl/src/streaming/mediaTimelineFilter.ts
@@ -9,6 +9,7 @@ import type {
     MediaTimeline,
 } from './MediaTimeline'
 import type { MediaQualityMetadata } from './MediaQualityMetadata'
+import { RESTRICTABLE_CONTENT_TYPES } from './MediaQualityMetadata'
 import type {
     FilterPredicate,
     FilterPredicateAsync,
@@ -17,8 +18,32 @@ import type {
 import { map, memoize } from '@amazon/vinyl-util'
 
 /**
+ * Throws via `throwError` when filtering drops every rendition of an audio or
+ * video stream the period originally carried. Each surviving media stream needs
+ * a source buffer to append to; a stream filtered to zero can never create one,
+ * stalling playback on an unfulfilled `readyToAppend`, so a whole-stream drop is
+ * treated as unsupported media rather than a silent stall. Text is excluded —
+ * captions are an optional sidecar pipeline, not an MSE source buffer.
+ */
+function assertMediaStreamsRetained(
+    original: readonly MediaQualityData[],
+    filtered: readonly MediaQualityData[],
+    throwError: () => never
+): void {
+    for (const contentType of RESTRICTABLE_CONTENT_TYPES) {
+        if (
+            original.some((q) => q.metadata.contentType === contentType) &&
+            !filtered.some((q) => q.metadata.contentType === contentType)
+        ) {
+            throwError()
+        }
+    }
+}
+
+/**
  * Filters qualities in a MediaTimeline using a synchronous predicate.
- * If filtering would remove all qualities from any period, throws via `throwError`.
+ * If filtering drops an audio or video stream to zero in any period, throws via
+ * `throwError`.
  */
 export function filterTimelineQualities(
     filter: Maybe<FilterPredicate<MediaQualityMetadata>>,
@@ -37,19 +62,17 @@ export function filterTimelineQualities(
         const filtered = period.qualities.filter((q, index) =>
             filter(q.metadata, index, mapMetadataArray(period.qualities))
         )
+        assertMediaStreamsRetained(period.qualities, filtered, throwError)
         return { ...period, qualities: filtered }
     })
-
-    if (periods.some((p) => p.qualities.length === 0)) {
-        throwError()
-    }
 
     return { ...timeline, periods }
 }
 
 /**
  * Filters qualities in a MediaTimeline using an asynchronous predicate.
- * If filtering would remove all qualities from any period, throws via `throwError`.
+ * If filtering drops an audio or video stream to zero in any period, throws via
+ * `throwError`.
  */
 export async function filterTimelineQualitiesAsync(
     filter: FilterPredicateAsync<MediaQualityMetadata>,
@@ -72,11 +95,8 @@ export async function filterTimelineQualitiesAsync(
                 filtered.push(period.qualities[i])
             }
         }
+        assertMediaStreamsRetained(period.qualities, filtered, throwError)
         periods.push({ ...period, qualities: filtered })
-    }
-
-    if (periods.some((p) => p.qualities.length === 0)) {
-        throwError()
     }
 
     return { ...timeline, periods }

--- a/packages/vinyl/src/track/filters/sampleRateFilter.ts
+++ b/packages/vinyl/src/track/filters/sampleRateFilter.ts
@@ -9,7 +9,6 @@ import {
     Browser,
     last,
     MediaUnsupportedError,
-    every,
     map,
     max,
     min,
@@ -38,10 +37,14 @@ export interface AudioSampleRateRangeOptions {
  * The upper bound is `maxSampleRate` when set, otherwise the platform's
  * `AudioContext`-reported output rate (Firefox is hard-capped at 48kHz, which it
  * cannot decode beyond via MSE). The optional lower bound is `minSampleRate`.
- * Both bounds are soft: if every audio rendition is above the max the lowest is
- * kept, and if every audio rendition is below the min the highest is kept, so
- * playback is never stranded. Only audio renditions count toward those
- * fallbacks — a co-present video quality (no audio rate) never influences them.
+ * Both bounds are soft, and soft *together*: when no audio rendition sits in the
+ * acceptable `[minSampleRate, maxSampleRate]` band, a single fallback is kept so
+ * playback is never stranded — the highest rate the ceiling can decode, or, when
+ * every rate is above the ceiling, the lowest. This holds even when renditions
+ * straddle an empty band (some below the floor, some above the ceiling). Only
+ * audio renditions count toward the fallback — a co-present video quality (no
+ * audio rate) never influences it. Firefox is the exception: its 48kHz cap is
+ * hard, with no fallback.
  */
 export function withinAudioSampleRateRange(
     options: AudioSampleRateRangeOptions,
@@ -49,36 +52,44 @@ export function withinAudioSampleRateRange(
     _index: number,
     array: ArrayLike<MediaQualityMetadata>
 ): boolean {
-    // Only audio renditions are gated on sampling rate; video and any other
-    // content type (including muxed video that happens to carry an audio rate)
-    // pass through untouched.
+    // Muxed video carrying an audio rate, and every non-audio type, pass through.
     if (metadata.contentType !== 'audio') return true
 
     const samplingRate = last(metadata.audioSamplingRate)
     if (!samplingRate) return true // sampling rate not set
 
-    const audioRates = () =>
+    const { minSampleRate } = options
+    // An explicit maxSampleRate takes precedence over the AudioContext rate.
+    const maxSampleRate =
+        options.maxSampleRate ?? options.capabilities.sampleRate
+
+    const audioRates = (): number[] =>
         map(array, (item) =>
             item.contentType === 'audio'
                 ? last(item.audioSamplingRate)
                 : undefined
         ).filter((rate): rate is number => rate != null)
 
-    // Lower bound (soft floor), independent of the platform max: below it, keep
-    // only the highest when every audio rendition is below the floor.
-    const { minSampleRate } = options
-    if (minSampleRate != null && samplingRate < minSampleRate) {
+    // The single rate to keep when this rendition is out of band — or undefined
+    // when some rendition IS in band, so out-of-band renditions are dropped.
+    // Evaluating both bounds together is what stops a straddle from stranding.
+    const outOfBandFallback = (): number | undefined => {
         const rates = audioRates()
-        return (
-            every(rates, (rate) => rate < minSampleRate) &&
-            samplingRate === max(rates)
-        )
+        const inBand = (rate: number): boolean =>
+            (minSampleRate == null || rate >= minSampleRate) &&
+            (!maxSampleRate || rate <= maxSampleRate)
+        if (rates.some(inBand)) return undefined
+        const decodable = maxSampleRate
+            ? rates.filter((rate) => rate <= maxSampleRate)
+            : rates
+        return decodable.length ? max(decodable) : min(rates)
     }
 
-    // Upper bound. An explicit maxSampleRate takes precedence over the
-    // AudioContext-reported output rate.
-    const maxSampleRate =
-        options.maxSampleRate ?? options.capabilities.sampleRate
+    // Lower bound (soft floor), independent of the platform max.
+    if (minSampleRate != null && samplingRate < minSampleRate) {
+        return samplingRate === outOfBandFallback()
+    }
+
     // No platform max to gauge support: keep. This also lets >48kHz through on
     // Firefox (its cap below is skipped) — accepted.
     if (!maxSampleRate) return true
@@ -89,10 +100,6 @@ export function withinAudioSampleRateRange(
     }
 
     if (samplingRate <= maxSampleRate) return true
-    // Above the max: keep only the lowest when every audio rendition exceeds it.
-    const rates = audioRates()
-    return (
-        every(rates, (rate) => rate > maxSampleRate) &&
-        samplingRate === min(rates)
-    )
+    // Above the ceiling (soft): keep only the fallback when no rate is in band.
+    return samplingRate === outOfBandFallback()
 }

--- a/packages/vinyl/src/track/mse/MseTrack.ts
+++ b/packages/vinyl/src/track/mse/MseTrack.ts
@@ -12,7 +12,6 @@ import {
     IntersectionRanges,
     logDebug,
     type Maybe,
-    MediaUnsupportedError,
     type ReadonlyRanges,
     type ReadonlySet,
     redispatchEvents,
@@ -123,10 +122,7 @@ export class MseTrack extends TrackBase {
         add(
             deps.contentTypesValue.onData((contentTypesPromise) => {
                 contentTypesPromise
-                    .then((value) => {
-                        this.setContentTypes(value)
-                        this.validateRequiredContentTypesPlayable()
-                    })
+                    .then((value) => this.setContentTypes(value))
                     .catch(this.errorHandler)
             })
         )
@@ -242,36 +238,7 @@ export class MseTrack extends TrackBase {
                     })
                 }
             }
-            this.validateRequiredContentTypesPlayable()
         })
-    }
-
-    /**
-     * Fails fast when a media content type the manifest declared (audio/video)
-     * has no playable qualities left after timeline filtering. Its stream can
-     * never create a source buffer, so without this the track waits forever for
-     * a source buffer that never arrives, surfacing only as an opaque
-     * `readyToAppend` timeout. Runs once both the required content types and the
-     * filtered timeline qualities are known (either order).
-     */
-    private validateRequiredContentTypesPlayable(): void {
-        const qualities = this._qualities
-        if (!qualities) return
-        const present = new Set(qualities.map((q) => q.contentType))
-        // contentTypesValue only ever yields audio/video (text is a sidecar
-        // pipeline, never an MSE source buffer), so every required type must
-        // have a playable quality left in the filtered timeline.
-        for (const contentType of this._contentTypes) {
-            if (!present.has(contentType)) {
-                this.errorHandler(
-                    new MediaUnsupportedError(
-                        `No playable ${contentType} rendition`,
-                        `no-playable-${contentType}`
-                    )
-                )
-                return
-            }
-        }
     }
 
     async getAds(): Promise<TrackAds> {

--- a/packages/vinyl/test/unit/streaming/MseTrack.test.ts
+++ b/packages/vinyl/test/unit/streaming/MseTrack.test.ts
@@ -22,7 +22,7 @@ import {
 import { createEventSpy, useMockLogger } from '@amazon/vinyl-util/testUtil'
 import { flushPromises } from '@amazon/vinyl-util/browserTestUtil'
 import { externalDependencies } from '@amazon/vinyl-di'
-import { Abort, MediaUnsupportedError } from '@amazon/vinyl-util'
+import { Abort } from '@amazon/vinyl-util'
 import any = jasmine.any
 
 describe('MseTrack', () => {
@@ -728,11 +728,12 @@ describe('MseTrack', () => {
             expect(track.qualitiesUnfiltered).toEqual([qualityMetadata])
         })
 
-        it('fails fast when a required content type is entirely filtered out', async () => {
-            // contentTypes (from the manifest) is {audio, video}, but the
-            // transformed timeline has only a video quality — audio was fully
-            // filtered. The audio stream could never create a source buffer, so
-            // the track must fail rather than stall on the readyToAppend wait.
+        it('plays the surviving content type when another is entirely filtered out', async () => {
+            // The content types now come from the FILTERED timeline: with every
+            // audio rendition filtered, only 'video' is required. No audio stream
+            // is created, so the load is never stranded waiting for an audio
+            // source buffer that will never arrive, and the track does not error.
+            deps.contentTypesValue.value = Promise.resolve(new Set(['video']))
             const videoQuality = {
                 ...createEmptyMediaQualityMetadata(),
                 contentType: 'video' as const,
@@ -757,10 +758,10 @@ describe('MseTrack', () => {
             })
             track = createTrack()
             await flushPromises()
-            expect(track.error).toEqual(any(MediaUnsupportedError))
-            expect((track.error as { code?: string }).code).toBe(
-                'no-playable-audio'
-            )
+            expect(track.error).toBeNull()
+            expect(track.contentTypes).toEqual(new Set(['video']))
+            expect(getStream('video')).not.toBeNull()
+            expect(getStream('audio')).toBeNull()
         })
 
         it('reads qualities from the filtered timeline but qualitiesUnfiltered from the raw one', async () => {

--- a/packages/vinyl/test/unit/streaming/mediaTimelineFilter.test.ts
+++ b/packages/vinyl/test/unit/streaming/mediaTimelineFilter.test.ts
@@ -7,12 +7,13 @@ import {
     createEmptyMediaQualityMetadata,
     filterTimelineQualities,
     filterTimelineQualitiesAsync,
+    type ContentType,
     type MediaQualityData,
     type MediaTimeline,
 } from '@amazon/vinyl'
 
 function createQuality(
-    contentType: 'audio' | 'video',
+    contentType: ContentType,
     bandwidth: number
 ): MediaQualityData {
     return {
@@ -25,113 +26,115 @@ function createQuality(
     }
 }
 
-describe('filterTimelineQualities', () => {
-    const timeline: MediaTimeline = {
-        periods: [
-            {
-                startTime: 0,
-                endTime: 10,
-                qualities: [
-                    createQuality('audio', 128000),
-                    createQuality('audio', 256000),
-                    createQuality('video', 500000),
-                ],
-            },
-        ],
+function timelineOf(qualities: readonly MediaQualityData[]): MediaTimeline {
+    return {
+        periods: [{ startTime: 0, endTime: 10, qualities: [...qualities] }],
         minBufferTime: 2,
         getAdBreaks: () => Promise.resolve([]),
         getDuration: () => Promise.resolve(Infinity),
     }
+}
+
+function contentTypesOf(timeline: MediaTimeline): Set<ContentType | null> {
+    return new Set(
+        timeline.periods[0].qualities.map((q) => q.metadata.contentType)
+    )
+}
+
+function throwEmpty(): never {
+    throw new Error('no qualities')
+}
+
+describe('filterTimelineQualities', () => {
+    const timeline = timelineOf([
+        createQuality('audio', 128000),
+        createQuality('audio', 256000),
+        createQuality('video', 500000),
+    ])
 
     it('returns the timeline unchanged when the filter is null', () => {
         // A null predicate (e.g. no language preference) is a no-op.
-        const result = filterTimelineQualities(
-            null,
-            () => {
-                throw new Error('empty')
-            },
-            timeline
-        )
+        const result = filterTimelineQualities(null, throwEmpty, timeline)
         expect(result).toBe(timeline)
     })
 
-    it('filters qualities by predicate', () => {
+    it('filters qualities by predicate while keeping every present stream', () => {
         const result = filterTimelineQualities(
-            (q) => q.contentType === 'audio',
-            () => {
-                throw new Error('empty')
-            },
+            (q) => q.bandwidth !== 256000,
+            throwEmpty,
             timeline
         )
         expect(result.periods[0].qualities.length).toBe(2)
-        expect(
-            result.periods[0].qualities.every(
-                (q) => q.metadata.contentType === 'audio'
-            )
-        ).toBeTrue()
+        expect(contentTypesOf(result)).toEqual(new Set(['audio', 'video']))
     })
 
     it('preserves minBufferTime', () => {
-        const result = filterTimelineQualities(
-            () => true,
-            () => {
-                throw new Error('empty')
-            },
-            timeline
-        )
+        const result = filterTimelineQualities(() => true, throwEmpty, timeline)
         expect(result.minBufferTime).toBe(2)
     })
 
     it('throws when filtering removes all qualities', () => {
         expect(() =>
+            filterTimelineQualities(() => false, throwEmpty, timeline)
+        ).toThrowError('no qualities')
+    })
+
+    it('throws when filtering drops a present video stream to zero', () => {
+        expect(() =>
             filterTimelineQualities(
-                () => false,
-                () => {
-                    throw new Error('no qualities')
-                },
+                (q) => q.contentType === 'audio',
+                throwEmpty,
                 timeline
             )
         ).toThrowError('no qualities')
     })
+
+    it('throws when filtering drops a present audio stream to zero', () => {
+        expect(() =>
+            filterTimelineQualities(
+                (q) => q.contentType === 'video',
+                throwEmpty,
+                timeline
+            )
+        ).toThrowError('no qualities')
+    })
+
+    it('does not throw when losing only an optional text sidecar stream', () => {
+        const withText = timelineOf([
+            createQuality('audio', 128000),
+            createQuality('video', 500000),
+            createQuality('text', 1000),
+        ])
+        const result = filterTimelineQualities(
+            (q) => q.contentType !== 'text',
+            throwEmpty,
+            withText
+        )
+        expect(contentTypesOf(result)).toEqual(new Set(['audio', 'video']))
+    })
 })
 
 describe('filterTimelineQualitiesAsync', () => {
-    const timeline: MediaTimeline = {
-        periods: [
-            {
-                startTime: 0,
-                endTime: 10,
-                qualities: [
-                    createQuality('audio', 128000),
-                    createQuality('video', 500000),
-                ],
-            },
-        ],
-        minBufferTime: 2,
-        getAdBreaks: () => Promise.resolve([]),
-        getDuration: () => Promise.resolve(Infinity),
-    }
+    const timeline = timelineOf([
+        createQuality('audio', 128000),
+        createQuality('audio', 256000),
+        createQuality('video', 500000),
+    ])
 
-    it('filters qualities by async predicate', async () => {
+    it('filters qualities by async predicate while keeping every present stream', async () => {
         const result = await filterTimelineQualitiesAsync(
-            (q) => Promise.resolve(q.contentType === 'audio'),
-            () => {
-                throw new Error('empty')
-            },
+            (q) => Promise.resolve(q.bandwidth !== 256000),
+            throwEmpty,
             timeline
         )
-        expect(result.periods[0].qualities.length).toBe(1)
-        expect(result.periods[0].qualities[0].metadata.contentType).toBe(
-            'audio'
-        )
+        expect(result.periods[0].qualities.length).toBe(2)
+        expect(contentTypesOf(result)).toEqual(new Set(['audio', 'video']))
     })
 
     it('preserves minBufferTime', async () => {
         const result = await filterTimelineQualitiesAsync(
             () => Promise.resolve(true),
-            () => {
-                throw new Error('empty')
-            },
+            throwEmpty,
             timeline
         )
         expect(result.minBufferTime).toBe(2)
@@ -141,11 +144,33 @@ describe('filterTimelineQualitiesAsync', () => {
         await expectAsync(
             filterTimelineQualitiesAsync(
                 () => Promise.resolve(false),
-                () => {
-                    throw new Error('no qualities')
-                },
+                throwEmpty,
                 timeline
             )
         ).toBeRejectedWithError('no qualities')
+    })
+
+    it('throws when filtering drops a present video stream to zero', async () => {
+        await expectAsync(
+            filterTimelineQualitiesAsync(
+                (q) => Promise.resolve(q.contentType === 'audio'),
+                throwEmpty,
+                timeline
+            )
+        ).toBeRejectedWithError('no qualities')
+    })
+
+    it('does not throw when losing only an optional text sidecar stream', async () => {
+        const withText = timelineOf([
+            createQuality('audio', 128000),
+            createQuality('video', 500000),
+            createQuality('text', 1000),
+        ])
+        const result = await filterTimelineQualitiesAsync(
+            (q) => Promise.resolve(q.contentType !== 'text'),
+            throwEmpty,
+            withText
+        )
+        expect(contentTypesOf(result)).toEqual(new Set(['audio', 'video']))
     })
 })

--- a/packages/vinyl/test/unit/track/filters/sampleRateFilter.test.ts
+++ b/packages/vinyl/test/unit/track/filters/sampleRateFilter.test.ts
@@ -299,6 +299,30 @@ describe('withinAudioSampleRateRange minSampleRate floor', () => {
         expect(withinMin(low, 0, [low, mid])).toBe(false)
     })
 
+    it('keeps the highest when every rate (of three) is below the floor', () => {
+        const low = audioQuality([16_000])
+        const mid = audioQuality([24_000])
+        const high = audioQuality([32_000])
+        expect(withinMin(high, 2, [low, mid, high])).toBe(true)
+        expect(withinMin(mid, 1, [low, mid, high])).toBe(false)
+        expect(withinMin(low, 0, [low, mid, high])).toBe(false)
+    })
+
+    it('keeps the highest below-floor rate when no platform max is reported', () => {
+        // No AudioContext rate, so the floor is the only bound; with every rate
+        // below it, the highest is kept as the fallback.
+        capabilities.sampleRate = null
+        const low = audioQuality([16_000])
+        const high = audioQuality([32_000])
+        expect(withinMin(high, 1, [low, high])).toBe(true)
+        expect(withinMin(low, 0, [low, high])).toBe(false)
+    })
+
+    it('keeps a single audio rendition below the floor', () => {
+        const only = audioQuality([24_000])
+        expect(withinMin(only, 0, [only])).toBe(true)
+    })
+
     it('ignores non-audio qualities in the floor fallback', () => {
         const audio = audioQuality([24_000]) // below the floor
         const video = createEmptyMediaQualityMetadata()
@@ -307,5 +331,76 @@ describe('withinAudioSampleRateRange minSampleRate floor', () => {
         // Below the 48kHz floor but the only audio → kept; video is ignored.
         expect(withinMin(audio, 0, [audio, video])).toBe(true)
         expect(withinMin(video, 1, [audio, video])).toBe(true)
+    })
+})
+
+// The floor and ceiling are soft together: when renditions straddle an empty
+// band (some below the floor, some above the ceiling, none in between) neither
+// bound alone must strand audio.
+describe('withinAudioSampleRateRange straddling an empty band', () => {
+    let capabilities: MockCapabilities
+
+    beforeEach(() => {
+        // The soft ceiling is a non-Firefox behavior; Firefox's 48kHz cap is
+        // hard (covered above), so pin a non-Firefox UA to exercise the fallback.
+        setUserAgent('Chrome')
+        capabilities = new MockCapabilities()
+        // Ceiling at 48kHz; floor at 44.1kHz → acceptable band is [44.1k, 48k].
+        capabilities.sampleRate = 48_000
+    })
+
+    function audioQuality(rate: number[] | null) {
+        const quality = createEmptyMediaQualityMetadata()
+        quality.contentType = 'audio'
+        quality.audioSamplingRate = rate
+        return quality
+    }
+
+    function within(
+        metadata: ReturnType<typeof audioQuality>,
+        index: number,
+        array: readonly ReturnType<typeof audioQuality>[]
+    ): boolean {
+        return withinAudioSampleRateRange(
+            { capabilities, minSampleRate: 44_100 },
+            metadata,
+            index,
+            array
+        )
+    }
+
+    it('keeps the highest decodable rate when one is below the floor and one above the ceiling', () => {
+        const low = audioQuality([22_050]) // below the 44.1kHz floor
+        const high = audioQuality([96_000]) // above the 48kHz ceiling
+        // Empty band → the below-floor rate is decodable and kept; the
+        // above-ceiling rate is dropped, so audio is never stranded.
+        expect(within(low, 0, [low, high])).toBe(true)
+        expect(within(high, 1, [low, high])).toBe(false)
+    })
+
+    it('keeps the below-floor rate when the ceiling matches the output device rate', () => {
+        // Output device runs at 44.1kHz, so a 48kHz rendition is above the
+        // ceiling while a 22.05kHz rendition is below the floor.
+        capabilities.sampleRate = 44_100
+        const low = audioQuality([22_050])
+        const high = audioQuality([48_000])
+        expect(within(low, 0, [low, high])).toBe(true)
+        expect(within(high, 1, [low, high])).toBe(false)
+    })
+
+    it('still prefers an in-band rate over the straddle fallback', () => {
+        const low = audioQuality([22_050]) // below floor
+        const mid = audioQuality([44_100]) // in band
+        const high = audioQuality([96_000]) // above ceiling
+        expect(within(mid, 1, [low, mid, high])).toBe(true)
+        expect(within(low, 0, [low, mid, high])).toBe(false)
+        expect(within(high, 2, [low, mid, high])).toBe(false)
+    })
+
+    it('keeps the lowest when every rate is above the ceiling', () => {
+        const low = audioQuality([88_200])
+        const high = audioQuality([96_000])
+        expect(within(low, 0, [low, high])).toBe(true)
+        expect(within(high, 1, [low, high])).toBe(false)
     })
 })


### PR DESCRIPTION
fix(streaming): derive readyToAppend content types from the filtered timeline

readyToAppend gated on content types from the manifest (allowlist only), so when a
quality filter removed all of a content type (e.g. all audio) the type still counted
and its source buffer never appeared -> readyToAppend never resolved -> silent stall.
Derive required content types from the FILTERED timeline (createTimelineContentTypesValue)
so video still plays when audio is fully filtered; remove the now-subsumed
MseTrack.validateRequiredContentTypesPlayable band-aid. BUL-296.

fix(streaming): don't strand audio when renditions straddle the sample-rate band

sampleRateFilter's soft floor and soft ceiling were evaluated independently, so a
rendition set straddling an empty [minSampleRate, maxSampleRate] band (some below
the floor, some above the ceiling, none in-band) failed both fallbacks and dropped
ALL audio. Replace with a shared outOfBandFallback that keeps a single decodable
rendition (highest the ceiling allows, else lowest) whenever nothing is in-band.
Surfaced after minSampleRate: 44100 was added.